### PR TITLE
add new model endpoints, deprecate legacy v2 routes, and switch postmarks to PostmarkV2

### DIFF
--- a/backend/common/api/v2/serializers.py
+++ b/backend/common/api/v2/serializers.py
@@ -6,6 +6,9 @@ from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from common.models import (
+    Region, PostOffice, Lettering, Framing, Shape, Cover, DateObserved,
+    Ratemark, Auxmark, CoverPostmark, PostmarkRatemark, MarkFraming,
+    ReferenceWork, Citation,
     PostalFacility, PostalFacilityIdentity,
     AdministrativeUnit, AdministrativeUnitIdentity, AdministrativeUnitResponsibility,
     JurisdictionalAffiliation,
@@ -62,6 +65,134 @@ class FAQEntrySerializer(serializers.ModelSerializer):
 
 
 # ========== GEOGRAPHIC HIERARCHY SERIALIZERS ==========
+
+class RegionSerializer(serializers.ModelSerializer):
+    """Serializer for v2 Region model."""
+
+    class Meta:
+        model = Region
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class PostOfficeSerializer(serializers.ModelSerializer):
+    """Serializer for v2 PostOffice model."""
+    region_name = serializers.CharField(source="region.name", read_only=True)
+
+    class Meta:
+        model = PostOffice
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class LetteringSerializer(serializers.ModelSerializer):
+    """Serializer for v2 Lettering model."""
+
+    class Meta:
+        model = Lettering
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class FramingSerializer(serializers.ModelSerializer):
+    """Serializer for v2 Framing model."""
+
+    class Meta:
+        model = Framing
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class ShapeSerializer(serializers.ModelSerializer):
+    """Serializer for v2 Shape model."""
+
+    class Meta:
+        model = Shape
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class CoverSerializer(serializers.ModelSerializer):
+    """Serializer for v2 Cover model."""
+    color_name = serializers.CharField(source="color.color_name", read_only=True)
+
+    class Meta:
+        model = Cover
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class DateObservedSerializer(serializers.ModelSerializer):
+    """Serializer for v2 DateObserved model."""
+
+    class Meta:
+        model = DateObserved
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class RatemarkSerializer(serializers.ModelSerializer):
+    """Serializer for v2 Ratemark model."""
+
+    class Meta:
+        model = Ratemark
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class AuxmarkSerializer(serializers.ModelSerializer):
+    """Serializer for v2 Auxmark model."""
+
+    class Meta:
+        model = Auxmark
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class CoverPostmarkSerializer(serializers.ModelSerializer):
+    """Serializer for v2 CoverPostmark model."""
+
+    class Meta:
+        model = CoverPostmark
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class PostmarkRatemarkSerializer(serializers.ModelSerializer):
+    """Serializer for v2 PostmarkRatemark model."""
+
+    class Meta:
+        model = PostmarkRatemark
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class MarkFramingSerializer(serializers.ModelSerializer):
+    """Serializer for v2 MarkFraming model."""
+
+    class Meta:
+        model = MarkFraming
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class ReferenceWorkSerializer(serializers.ModelSerializer):
+    """Serializer for v2 ReferenceWork model."""
+
+    class Meta:
+        model = ReferenceWork
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
+
+class CitationSerializer(serializers.ModelSerializer):
+    """Serializer for v2 Citation model."""
+
+    class Meta:
+        model = Citation
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "modified_at"]
+
 
 class AdministrativeUnitListSerializer(serializers.ModelSerializer):
     """Lightweight serializer for lists"""
@@ -307,7 +438,7 @@ class PostmarkV2Serializer(serializers.ModelSerializer):
     class Meta:
         model = PostmarkV2
         fields = '__all__'
-        read_only_fields = ['id', 'created_date', 'modified_date']
+        read_only_fields = ['id', 'created_at', 'modified_at']
 
 
 class PostmarkImageSerializer(serializers.ModelSerializer):

--- a/backend/common/api/v2/urls.py
+++ b/backend/common/api/v2/urls.py
@@ -13,76 +13,92 @@ router = DefaultRouter()
 
 # ========== GEOGRAPHIC & JURISDICTIONAL CORE ==========
 
-# Postal facilities (stable containers + identities + jurisdiction)
+# New v2 geography models
 router.register(
-    r"postal-facilities",
-    views.PostalFacilityViewSet,
-    basename="postal-facility",
+    r"regions",
+    views.RegionViewSet,
+    basename="region",
 )
 router.register(
-    r"postal-facility-identities",
-    views.PostalFacilityIdentityViewSet,
-    basename="postal-facility-identity",
+    r"post-offices",
+    views.PostOfficeViewSet,
+    basename="post-office",
+)
+router.register(
+    r"letterings",
+    views.LetteringViewSet,
+    basename="lettering",
+)
+router.register(
+    r"framings",
+    views.FramingViewSet,
+    basename="framing",
+)
+router.register(
+    r"shapes",
+    views.ShapeViewSet,
+    basename="shape",
+)
+router.register(
+    r"covers",
+    views.CoverV2ViewSet,
+    basename="cover-v2",
+)
+router.register(
+    r"dates-observed",
+    views.DateObservedViewSet,
+    basename="date-observed",
+)
+router.register(
+    r"ratemarks",
+    views.RatemarkViewSet,
+    basename="ratemark",
+)
+router.register(
+    r"auxmarks",
+    views.AuxmarkViewSet,
+    basename="auxmark",
+)
+router.register(
+    r"cover-postmarks",
+    views.CoverPostmarkV2ViewSet,
+    basename="cover-postmark-v2",
+)
+router.register(
+    r"postmark-ratemarks",
+    views.PostmarkRatemarkViewSet,
+    basename="postmark-ratemark",
+)
+router.register(
+    r"mark-framings",
+    views.MarkFramingViewSet,
+    basename="mark-framing",
+)
+router.register(
+    r"reference-works",
+    views.ReferenceWorkViewSet,
+    basename="reference-work",
+)
+router.register(
+    r"citations",
+    views.CitationViewSet,
+    basename="citation",
 )
 
-# Administrative units (stable containers + identities + group responsibilities)
-router.register(
-    r"administrative-units",
-    views.AdministrativeUnitViewSet,
-    basename="administrative-unit",
-)
-router.register(
-    r"administrative-unit-identities",
-    views.AdministrativeUnitIdentityViewSet,
-    basename="administrative-unit-identity",
-)
-router.register(
-    r"administrative-unit-responsibilities",
-    views.AdministrativeUnitResponsibilityViewSet,
-    basename="administrative-unit-responsibility",
-)
+# ========== SHARED LOOKUPS ==========
 
-# Jurisdictional links between facilities and units
-router.register(
-    r"jurisdictional-affiliations",
-    views.JurisdictionalAffiliationViewSet,
-    basename="jurisdictional-affiliation",
-)
-
-# ========== PHYSICAL CHARACTERISTICS ==========
-
-router.register(
-    r"postmark-shapes",
-    views.PostmarkShapeViewSet,
-    basename="postmark-shape",
-)
-router.register(
-    r"lettering-styles",
-    views.LetteringStyleViewSet,
-    basename="lettering-style",
-)
-router.register(
-    r"framing-styles",
-    views.FramingStyleViewSet,
-    basename="framing-style",
-)
 router.register(
     r"colors",
     views.ColorViewSet,
     basename="color",
-)
-router.register(
-    r"date-formats",
-    views.DateFormatViewSet,
-    basename="date-format",
 )
 
 # ========== POSTMARKS ==========
 
 router.register(
     r"postmarks",
-    views.PostmarkViewSet,
-    basename="postmark",
+    views.PostmarkV2ViewSet,
+    basename="postmark-v2",
 )
 router.register(
     r"postmark-images",
@@ -95,31 +111,10 @@ router.register(
     basename="postmark-valuation",
 )
 
-# ========== PUBLICATIONS ==========
-
-router.register(
-    r"publications",
-    views.PostmarkPublicationViewSet,
-    basename="publication",
-)
-router.register(
-    r"publication-references",
-    views.PostmarkPublicationReferenceViewSet,
-    basename="publication-reference",
-)
-
-# ========== POSTCOVERS ==========
-
-router.register(
-    r"postcovers",
-    views.PostcoverViewSet,
-    basename="postcover",
-)
-router.register(
-    r"postcover-images",
-    views.PostcoverImageViewSet,
-    basename="postcover-image",
-)
+# Note: legacy v1-oriented resources intentionally removed from v2 router:
+# postal-facilities, administrative-units, jurisdictional-affiliations,
+# postmark-shapes/lettering-styles/framing-styles/date-formats,
+# publications/publication-references, and postcovers/postcover-images.
 
 # ========== ADMIN (STAFF ONLY) ==========
 
@@ -153,7 +148,6 @@ urlpatterns = [
     path("contributions/", csrf_exempt(views.ContributionView.as_view()), name="contribution"),
     path("postmarks/<int:pk>/delete-mine/", views.DeleteMySubmissionView.as_view(), name="postmark-delete-mine"),
     path("me/", views.CurrentUserView.as_view(), name="current-user"),
-    path("assigned-states/", views.AssignedStatesView.as_view(), name="assigned-states"),
     path("postmarks-range/", views.PostmarkDateRangeView.as_view(), name="postmarks-range"),
     path("", include(router.urls)),
 ]

--- a/backend/common/api/v2/views.py
+++ b/backend/common/api/v2/views.py
@@ -38,23 +38,30 @@ from django.contrib.auth import get_user_model
 from woco.pagination import PageSizePagination, LargePageSizePagination, PostmarkListPagination
 
 from common.models import (
+    Region, PostOffice, Lettering, Framing, Shape, Cover, DateObserved,
+    Ratemark, Auxmark, CoverPostmark, PostmarkRatemark, MarkFraming,
+    ReferenceWork, Citation,
     PostalFacility, PostalFacilityIdentity,
     AdministrativeUnit, AdministrativeUnitIdentity, AdministrativeUnitResponsibility,
     JurisdictionalAffiliation,
     PostmarkShape, LetteringStyle, FramingStyle, Color, DateFormat,
-    Postmark, PostmarkColor, PostmarkDatesSeen, PostmarkSize,
+    Postmark, PostmarkV2, PostmarkColor, PostmarkDatesSeen, PostmarkSize,
     PostmarkValuation, PostmarkPublication, PostmarkPublicationReference,
     PostmarkImage, Postcover, PostcoverPostmark, PostcoverImage,
     AdminCsvUpload, UserLocationAssignment, Contribution, FAQEntry,
 )
 
 from .serializers import (
+    RegionSerializer, PostOfficeSerializer, LetteringSerializer, FramingSerializer,
+    ShapeSerializer, CoverSerializer, DateObservedSerializer, RatemarkSerializer,
+    AuxmarkSerializer, CoverPostmarkSerializer, PostmarkRatemarkSerializer,
+    MarkFramingSerializer, ReferenceWorkSerializer, CitationSerializer,
     PostalFacilitySerializer, PostalFacilityListSerializer,
     PostalFacilityIdentitySerializer, AdministrativeUnitSerializer,
     AdministrativeUnitListSerializer, AdministrativeUnitIdentitySerializer,
     AdministrativeUnitResponsibilitySerializer, JurisdictionalAffiliationSerializer,
     PostmarkShapeSerializer, LetteringStyleSerializer, FramingStyleSerializer,
-    ColorSerializer, DateFormatSerializer, PostmarkSerializer,
+    ColorSerializer, DateFormatSerializer, PostmarkSerializer, PostmarkV2Serializer,
     PostmarkListSerializer, PostmarkColorSerializer, PostmarkDatesSeenSerializer,
     PostmarkSizeSerializer, PostmarkValuationSerializer, PostmarkPublicationSerializer,
     PostmarkPublicationReferenceSerializer, PostmarkImageSerializer,
@@ -1482,6 +1489,274 @@ class DeleteMySubmissionView(APIView):
 
 
 # ========== GEOGRAPHIC HIERARCHY VIEWSETS ==========
+
+class RegionViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 regions."""
+    queryset = Region.objects.all().select_related("parent_region")
+    serializer_class = RegionSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ["region_tier", "parent_region"]
+    search_fields = ["name", "abbrev"]
+    ordering_fields = ["name", "abbrev", "established_date", "defunct_date", "created_at"]
+    ordering = ["name"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class PostOfficeViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 post offices."""
+    queryset = PostOffice.objects.all().select_related("region")
+    serializer_class = PostOfficeSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ["region"]
+    search_fields = ["name", "region__name", "region__abbrev"]
+    ordering_fields = ["name", "created_at"]
+    ordering = ["name"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class LetteringViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 lettering values."""
+    queryset = Lettering.objects.all()
+    serializer_class = LetteringSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["name"]
+    ordering_fields = ["name", "created_at"]
+    ordering = ["name"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class FramingViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 framing values."""
+    queryset = Framing.objects.all()
+    serializer_class = FramingSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["name", "code"]
+    ordering_fields = ["name", "code", "created_at"]
+    ordering = ["name"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class ShapeViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 shape values."""
+    queryset = Shape.objects.all()
+    serializer_class = ShapeSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["name", "code"]
+    ordering_fields = ["name", "code", "created_at"]
+    ordering = ["name"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class CoverV2ViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 covers."""
+    queryset = Cover.objects.all().select_related("color")
+    serializer_class = CoverSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filterset_fields = ["color", "type", "has_adhesive", "is_institutional"]
+    ordering_fields = ["id", "code", "created_at"]
+    ordering = ["id"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class DateObservedViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 postmark observed dates."""
+    queryset = DateObserved.objects.all().select_related("postmark")
+    serializer_class = DateObservedSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filterset_fields = ["postmark", "granularity"]
+    ordering_fields = ["date", "created_at"]
+    ordering = ["postmark", "date"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class RatemarkViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 ratemarks."""
+    queryset = Ratemark.objects.all().select_related("shape", "lettering", "color")
+    serializer_class = RatemarkSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ["is_manuscript", "shape", "lettering", "color", "impression", "is_irreg"]
+    search_fields = ["inscription_txt"]
+    ordering_fields = ["id", "created_at"]
+    ordering = ["id"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class AuxmarkViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 auxiliary marks."""
+    queryset = Auxmark.objects.all().select_related("shape", "lettering", "color")
+    serializer_class = AuxmarkSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ["parent_mark_type", "parent_mark_id", "is_manuscript", "shape", "lettering", "color"]
+    search_fields = ["inscription_text"]
+    ordering_fields = ["parent_mark_type", "parent_mark_id", "created_at"]
+    ordering = ["parent_mark_type", "parent_mark_id"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class CoverPostmarkV2ViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 cover-postmark links."""
+    queryset = CoverPostmark.objects.all().select_related("cover", "postmark")
+    serializer_class = CoverPostmarkSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filterset_fields = ["cover", "postmark", "is_backstamp"]
+    ordering_fields = ["id", "created_at"]
+    ordering = ["id"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class PostmarkRatemarkViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 postmark-ratemark links."""
+    queryset = PostmarkRatemark.objects.all().select_related("postmark", "ratemark")
+    serializer_class = PostmarkRatemarkSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filterset_fields = ["postmark", "ratemark", "placement_type"]
+    ordering_fields = ["id", "created_at"]
+    ordering = ["id"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class MarkFramingViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 mark-framing links."""
+    queryset = MarkFraming.objects.all().select_related("framing")
+    serializer_class = MarkFramingSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filterset_fields = ["parent_mark_type", "parent_mark_id", "framing"]
+    ordering_fields = ["id", "framing_pos", "created_at"]
+    ordering = ["parent_mark_type", "parent_mark_id"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class ReferenceWorkViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 reference works."""
+    queryset = ReferenceWork.objects.all()
+    serializer_class = ReferenceWorkSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ["publication_year"]
+    search_fields = ["title", "authorship", "publisher", "edition", "volume", "isbn"]
+    ordering_fields = ["title", "publication_year", "created_at"]
+    ordering = ["title"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class CitationViewSet(viewsets.ModelViewSet):
+    """ViewSet for v2 citations."""
+    queryset = Citation.objects.all().select_related("reference_work")
+    serializer_class = CitationSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ["reference_work", "subject_type", "subject_id"]
+    search_fields = ["citation_detail", "reference_work__title"]
+    ordering_fields = ["reference_work", "subject_type", "subject_id", "created_at"]
+    ordering = ["reference_work", "subject_type", "subject_id"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
+
+class PostmarkV2ViewSet(viewsets.ModelViewSet):
+    """Canonical v2 postmark CRUD based on PostmarkV2 model."""
+    queryset = PostmarkV2.objects.all().select_related(
+        "postmark", "post_office", "shape", "lettering", "color", "date_format"
+    )
+    serializer_class = PostmarkV2Serializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = [
+        "postmark", "post_office", "shape", "lettering", "color", "is_manuscript",
+        "impression", "is_irreg", "date_type", "date_fmt", "visibility",
+        "contribution_approval_status",
+    ]
+    search_fields = ["code", "postmark_key", "inscription_txt", "catalog_txt"]
+    ordering_fields = ["id", "postmark_key", "code", "created_at"]
+    ordering = ["id"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user, modified_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
+
 
 class PostalFacilityViewSet(viewsets.ModelViewSet):
     """

--- a/postman/worldcovers-local.postman_environment.json
+++ b/postman/worldcovers-local.postman_environment.json
@@ -1,0 +1,26 @@
+{
+  "id": "ad24783f-6cde-44f4-92a0-55f341074ba9",
+  "name": "WorldCovers Local",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://127.0.0.1:8000",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "username",
+      "value": "admin",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "password",
+      "value": "admin",
+      "type": "secret",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-03-24T00:00:00.000Z"
+}

--- a/postman/worldcovers-v2.postman_collection.json
+++ b/postman/worldcovers-v2.postman_collection.json
@@ -1,0 +1,130 @@
+{
+  "info": {
+    "_postman_id": "2f6ebd0f-3f6f-4f7d-8aa9-7ea2c9d7c4f1",
+    "name": "WorldCovers API v2",
+    "description": "Postman collection for WorldCovers v2 APIs with CRUD requests.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "noauth"
+  },
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Login",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"{{username}}\",\n  \"password\": \"{{password}}\"\n}"
+            },
+            "url": "{{baseUrl}}/api/v2/login/"
+          }
+        },
+        { "name": "Current User", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/me/" } },
+        { "name": "Logout", "request": { "method": "POST", "url": "{{baseUrl}}/api/v2/logout/" } }
+      ]
+    },
+    {
+      "name": "Postmarks V2 CRUD",
+      "item": [
+        { "name": "List", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/postmarks/" } },
+        {
+          "name": "Create",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"postmark\": {{postmark_id}},\n  \"post_office\": {{post_office_id}},\n  \"shape\": {{shape_id}},\n  \"lettering\": {{lettering_id}},\n  \"color\": {{color_id}},\n  \"is_manuscript\": false,\n  \"impression\": \"Normal\",\n  \"rate_location\": \"NONE\",\n  \"rate_value\": \"\",\n  \"visibility\": \"PUBLIC\"\n}"
+            },
+            "url": "{{baseUrl}}/api/v2/postmarks/"
+          }
+        },
+        { "name": "Retrieve", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/postmarks/{{postmark_v2_id}}/" } },
+        {
+          "name": "Update",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"postmark\": {{postmark_id}},\n  \"post_office\": {{post_office_id}},\n  \"shape\": {{shape_id}},\n  \"lettering\": {{lettering_id}},\n  \"color\": {{color_id}},\n  \"is_manuscript\": false,\n  \"impression\": \"Normal\",\n  \"rate_location\": \"NONE\",\n  \"rate_value\": \"5c\",\n  \"visibility\": \"PUBLIC\"\n}"
+            },
+            "url": "{{baseUrl}}/api/v2/postmarks/{{postmark_v2_id}}/"
+          }
+        },
+        {
+          "name": "Delete",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/api/v2/postmarks/{{postmark_v2_id}}/" }
+        }
+      ]
+    },
+    {
+      "name": "Regions CRUD",
+      "item": [
+        { "name": "List", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/regions/" } },
+        { "name": "Create", "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"name\": \"Virginia\",\n  \"abbrev\": \"VA\",\n  \"region_tier\": \"STATE\"\n}" }, "url": "{{baseUrl}}/api/v2/regions/" } },
+        { "name": "Retrieve", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/regions/{{region_id}}/" } },
+        { "name": "Update", "request": { "method": "PUT", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"name\": \"Virginia\",\n  \"abbrev\": \"VA\",\n  \"region_tier\": \"STATE\"\n}" }, "url": "{{baseUrl}}/api/v2/regions/{{region_id}}/" } },
+        { "name": "Delete", "request": { "method": "DELETE", "url": "{{baseUrl}}/api/v2/regions/{{region_id}}/" } }
+      ]
+    },
+    {
+      "name": "Post Offices CRUD",
+      "item": [
+        { "name": "List", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/post-offices/" } },
+        { "name": "Create", "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"name\": \"Richmond\",\n  \"region\": {{region_id}}\n}" }, "url": "{{baseUrl}}/api/v2/post-offices/" } },
+        { "name": "Retrieve", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/post-offices/{{post_office_id}}/" } },
+        { "name": "Update", "request": { "method": "PUT", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"name\": \"Richmond\",\n  \"region\": {{region_id}}\n}" }, "url": "{{baseUrl}}/api/v2/post-offices/{{post_office_id}}/" } },
+        { "name": "Delete", "request": { "method": "DELETE", "url": "{{baseUrl}}/api/v2/post-offices/{{post_office_id}}/" } }
+      ]
+    },
+    {
+      "name": "Simple Lookup CRUD",
+      "item": [
+        { "name": "Letterings List", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/letterings/" } },
+        { "name": "Framings List", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/framings/" } },
+        { "name": "Shapes List", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/shapes/" } },
+        { "name": "Colors List", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/colors/" } }
+      ]
+    },
+    {
+      "name": "Other v2 Endpoints",
+      "item": [
+        { "name": "Covers", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/covers/" } },
+        { "name": "Dates Observed", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/dates-observed/" } },
+        { "name": "Ratemarks", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/ratemarks/" } },
+        { "name": "Auxmarks", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/auxmarks/" } },
+        { "name": "Cover Postmarks", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/cover-postmarks/" } },
+        { "name": "Postmark Ratemarks", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/postmark-ratemarks/" } },
+        { "name": "Mark Framings", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/mark-framings/" } },
+        { "name": "Reference Works", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/reference-works/" } },
+        { "name": "Citations", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/citations/" } },
+        { "name": "Postmark Images", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/postmark-images/" } },
+        { "name": "Postmark Valuations", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/postmark-valuations/" } },
+        { "name": "FAQ Entries", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/faq-entries/" } },
+        { "name": "Contributions", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/contributions/" } },
+        { "name": "Postmarks Range", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/postmarks-range/" } },
+        { "name": "Admin CSV Uploads", "request": { "method": "GET", "url": "{{baseUrl}}/api/v2/admin-csv-uploads/" } }
+      ]
+    }
+  ],
+  "variable": [
+    { "key": "baseUrl", "value": "http://127.0.0.1:8000" },
+    { "key": "username", "value": "admin" },
+    { "key": "password", "value": "admin" },
+    { "key": "postmark_id", "value": "1" },
+    { "key": "postmark_v2_id", "value": "1" },
+    { "key": "region_id", "value": "1" },
+    { "key": "post_office_id", "value": "1" },
+    { "key": "shape_id", "value": "1" },
+    { "key": "lettering_id", "value": "1" },
+    { "key": "color_id", "value": "1" }
+  ]
+}


### PR DESCRIPTION
This PR aligns v2 APIs with the newer APMC domain models by adding full CRUD endpoints for new entities (regions, post-offices, letterings, framings, shapes, covers, dates-observed, ratemarks, auxmarks, cover-postmarks, postmark-ratemarks, mark-framings, reference-works, citations). It also deprecates legacy v1-style routes from v2 routing (without removing any tables/models, so v1 remains intact), and updates /api/v2/postmarks/ to use PostmarkV2 as the canonical v2 resource.

Additionally, Postman artifacts were refreshed with the updated v2 API surface, including CRUD flows for key resources, to support QA and integration testing.