### PR TITLE
Clear CI build warnings: action bumps, step reorder, W036 silence

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Fail fast if any known malware fingerprint is present in the tree.
       # Runs before any install / build step so a compromised commit cannot
@@ -22,7 +22,7 @@ jobs:
         run: bash tools/fingerprint.sh
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           # Pin uv version so CI is deterministic. Bump deliberately.
           version: "0.11.2"
@@ -30,7 +30,7 @@ jobs:
           # Python version comes from .python-version at repo root (3.13).
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -39,6 +39,16 @@ jobs:
       - name: Install Python dependencies
         # Same flags as the server: locked resolution, no dev group.
         run: uv sync --no-dev --frozen
+
+      # Build the frontend before running Django system checks. Django's
+      # STATICFILES_DIRS points at frontend/dist/, and `manage.py check`
+      # raises staticfiles.W004 if that directory is missing. Building
+      # first keeps the check log clean.
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm ci
+          npm run build
 
       # `migrate --check` was the original step here, but it needs a live
       # MySQL to inspect django_migrations and CI doesn't provide one, so it
@@ -59,14 +69,8 @@ jobs:
           DJANGO_SECRET_KEY: ci-dummy-not-a-real-secret-do-not-use-anywhere
         run: uv run python backend/manage.py check
 
-      - name: Build frontend
-        run: |
-          cd frontend
-          npm ci
-          npm run build
-
       - name: Upload frontend build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: frontend-dist
           path: frontend/dist/
@@ -90,6 +94,11 @@ jobs:
           command_timeout: 20m
           script: |
             set -euo pipefail
+            # Non-interactive SSH does not source .bashrc / .profile, so
+            # user-level installs (uv lives at ~/.local/bin/uv by default)
+            # are not on PATH. Add the standard user-bin directory so the
+            # deploy script can find uv without a system-wide install.
+            export PATH="$HOME/.local/bin:$PATH"
             # Stop the app so migrations can run without table locks
             # (ALTER TABLE on Postmarks can block otherwise).
             sudo -n /bin/systemctl stop worldcovers

--- a/backend/woco/settings.py
+++ b/backend/woco/settings.py
@@ -137,6 +137,11 @@ DATABASES = {
     }
 }
 
+# MariaDB cannot enforce partial unique constraints, so allauth's
+# account.EmailAddress model triggers models.W036 on every manage.py
+# check. Uniqueness is still enforced in application code by allauth.
+SILENCED_SYSTEM_CHECKS = ["models.W036"]
+
 # Password validation
 # https://docs.djangoproject.com/en/5.2/ref/settings/#auth-password-validators
 AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
## Summary

PR 1 of 2 from the build/deploy warnings plan. CI-only changes; no application behavior changes.

- Bump Node-based actions to versions running on Node 24 (checkout v5, setup-node v5, upload-artifact v5, setup-uv v7) ahead of GitHub's June 2, 2026 Node 20 cutoff.
- Run "Build frontend" before "Django system checks" so the STATICFILES_DIRS entry exists when manage.py check runs, clearing staticfiles.W004.
- Silence models.W036: allauth's EmailAddress partial unique constraint is unenforceable on MariaDB but uniqueness is still enforced in application code by allauth.
- Export PATH on the SSH deploy step so non-interactive shells pick up the user-local uv install (carried over from last session's deploy fixes).

PR 2 (frontend security patches, bundle splitting, tailwind v4) will follow once this lands.

## Test plan

- [ ] Workflow run on this branch's push succeeds end-to-end
- [ ] No "Node.js 20 actions are deprecated" warning in the Complete job step
- [ ] No staticfiles.W004 or models.W036 lines in the Django system checks step
- [ ] Deploy step still succeeds and the staging site comes back up

Note: workflow only triggers on push to staging, so CI verification happens post-merge.

Generated with [Claude Code](https://claude.com/claude-code)