### PR TITLE
Michigan pre-statehood: section-driven region assignment + VA pipeline fixes

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -165,6 +165,22 @@ post_offices (1057), post_office_regions (1057), markings (2813), dates_seen
 > Without it the munger aborts with "PostOffice normalization produced N
 > name(s) with characters outside [A-Z, space, period, single dash]."
 
+**Verify the "Section-region assignment" report** printed at the top of the
+munge output. Listings are assigned the region of the catalog section they
+sit under (META banners matching a TERRITORY-tier name in `regions.csv`,
+optionally prefixed `AS `; a `STATEHOOD` banner resets to the catalog's
+default region). Check that:
+
+- the per-region listing counts match the catalog's section sizes
+  (single-region catalogs like VA show one line: all listings on the default);
+- nothing under "Unmatched banner-like META rows" is a real territory
+  section the vision step misread (e.g. `MICHIGAN TERRlTORY`) — if it is,
+  fix the row in the extract CSV and re-munge.
+
+A post office listed under several sections (e.g. Detroit) gets one
+`post_office_regions` row per section region, so junction-row count can
+exceed post-office count on territory-bearing catalogs.
+
 ## G. Import  (deterministic, no API)
 
 ```bash

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,0 +1,251 @@
+# ASCC Catalog Pipeline — Runbook
+
+Turn a state sub-catalog PDF into rows in the WorldCovers database. This is the
+canonical, reproducible path; it supersedes the notebook chain described in
+`docs/devel/TOOLS.md` (those notebooks no longer exist — the pipeline is now the
+`tools/ascc_*.py` scripts below).
+
+**Validated end-to-end against Virginia (`VA_ASCC_CTLG`), 2026-06-09.**
+
+---
+
+## 0. Prerequisites
+
+| Need | How |
+|------|-----|
+| Python env | `uv sync` in repo root (set `CC=gcc CXX=g++` if `mysqlclient` fails to build) |
+| MySQL DB | `worldcovers` DB migrated; see `tools/rebuild_staging_db.sh`. Work on `staging` branch (see `DECISIONS.md` re: `main` migration bug) |
+| `pdftoppm` | poppler-utils. `sudo apt-get install -y poppler-utils`, or no-sudo `brew install poppler` |
+| `OPENROUTER_API_KEY` | in **`worldcovers/.env`** (the scripts load `TOOLS_DIR.parent/.env`, i.e. the repo-root `.env`, NOT the workspace-root one). Account must have credit — the vision stages call the paid model `anthropic/claude-sonnet-4.6` |
+
+### The `BASE` convention
+
+Every script keys off one basename, e.g. `VA_ASCC_CTLG`. It must:
+- be the input PDF's filename stem: `tools/wip/in/<BASE>.pdf`
+- start with the 2-letter region abbrev (`VA`) — the munger derives `REGION_ABBREV`
+  from `os.path.basename(input)[:2]`, and the processor/extract derive the state
+  header (`VA` → `VIRGINIA`) from the first `_`-delimited token via `regions.csv`.
+
+> All of `tools/wip/{in,out,cache}/` is gitignored (incl. all pdf/png/jpg) — safe scratch.
+
+### Seed files (place in `tools/wip/in/` before starting)
+
+- `<BASE>.pdf` — the state sub-catalog
+- `reference_works.csv` — **exactly 1 data row** (the catalog being cited); munger raises otherwise
+- `regions.csv` — must contain exactly 1 row matching `REGION_ABBREV`
+
+---
+
+## Stage map
+
+| # | Script | API? | Reads | Writes |
+|---|--------|------|-------|--------|
+| A | `ascc_page_processor.py … --stages render` | no | `wip/in/<BASE>.pdf` | `wip/cache/<BASE>_full/page-*.png` |
+| B | `ascc_page_processor.py … --stages halves` | ✅ | full pages | `wip/cache/<BASE>_halves/` |
+| C | `ascc_page_processor.py … --stages chunks` | ✅ | halves | `wip/out/<BASE>/page-NNNN-MMMM.png` |
+| — | **hop 1** | — | move chunks `wip/out/<BASE>/` → `wip/in/<BASE>/` | extract/image_extract read from `in/` |
+| D | `ascc_page_extract.py <BASE>` | ✅ | `wip/in/<BASE>/` chunks | `wip/out/<BASE>.csv` |
+| E | `ascc_image_extract.py <BASE>` | no | `wip/in/<BASE>/` chunks + `wip/out/<BASE>.csv` | `wip/out/<BASE>_images/` |
+| F | `ascc_data_munger.py --input … --input-dir …` | no | extract CSV + seeds + images | Django-shape CSVs in `wip/out/` |
+| G | `manage.py import_ascc_bundle <out-dir>` | no | the bundle | rows in MySQL |
+
+All commands run from the repo root (`worldcovers/`).
+
+---
+
+## A. Render  (deterministic)
+
+```bash
+uv run python tools/ascc_page_processor.py VA_ASCC_CTLG --stages render
+```
+
+Result (VA): **17 pages** rendered at 300 DPI → `wip/cache/VA_ASCC_CTLG_full/`.
+
+## B. Halves  (vision)
+
+```bash
+uv run python tools/ascc_page_processor.py VA_ASCC_CTLG --stages halves
+```
+
+Per page: deterministic vertical-rule detection, with a vision page-number read
+and a single-column-confirm fallback. Crops to L/R halves named by **catalog**
+page number.
+
+Result (VA): catalog pages **419–435**, **34 half-images**, 20 vision calls
+(4 `vision_confirmed_weak_rule`). **Inspect a sampling of halves for seam-clipped
+text/markings before proceeding** (the script reminds you).
+
+## C. Chunks  (vision)
+
+```bash
+uv run python tools/ascc_page_processor.py VA_ASCC_CTLG --stages chunks
+```
+
+Per half: deterministic dark/blank row-block detection + vision per-block
+classify (illustration vs text); cut at the top of every illustration block.
+
+Result (VA): 795 blocks detected, 173 illustrations, **201 chunk PNGs** →
+`wip/out/VA_ASCC_CTLG/page-NNNN-MMMM.png` (~34 min; 795 classify + 197 review
+vision calls).
+
+## hop 1 — move chunks where the downstream scripts read them
+
+The processor writes chunks to `wip/out/<BASE>/`, but `ascc_page_extract.py` and
+`ascc_image_extract.py` both read from `wip/in/<BASE>/`. Move them:
+
+```bash
+mkdir -p tools/wip/in/VA_ASCC_CTLG
+mv tools/wip/out/VA_ASCC_CTLG/* tools/wip/in/VA_ASCC_CTLG/
+```
+
+## D. Extract  (vision)
+
+```bash
+uv run python tools/ascc_page_extract.py VA_ASCC_CTLG
+```
+
+Sends each chunk to the vision model; writes catalog rows (Listing, Page,
+Chunk, Images Above, Type) to `wip/out/VA_ASCC_CTLG.csv`.
+
+Result (VA): **1,596 rows** (1,539 LISTING + 57 META), 167 chunks with
+`Images Above >= 1` (~22 min).
+
+> **Per-chunk review (the "reviewed CSV"):** the vision pass can over-count
+> markings on a noisy chunk. VA page 419 chunk 14 was tagged `Images Above=2`
+> but contains only one marking (a cursive "Nfk" manuscript mark; the ornate
+> "NORFOLK" below is a section banner, not a marking). image-extract (next
+> step) refuses to fabricate the 2nd image and flags `marking_count_mismatch`,
+> and the munger then aborts on the missing file. Fix: correct that row's
+> `Images Above` to the true count in the CSV and re-run image-extract for the
+> page. This is the human review the pipeline assumes between extract and munge.
+
+## E. Image extract  (deterministic, no API)
+
+```bash
+uv run python tools/ascc_image_extract.py VA_ASCC_CTLG
+```
+
+For each chunk with `Images Above >= 1`, cuts the marking illustration(s) out by
+gap/dark-region geometry (no vision). Writes
+`wip/out/VA_ASCC_CTLG_images/va-<page>-<chunk>-<counter>.png`. Use `--pages 419`
+to re-run a single page after a review correction.
+
+Result (VA): 167 subchunks, **205 marking images** (after the chunk-14 review
+fix; 204 before), all `ok`.
+
+### hop 2 — copy marking images into Django's media root
+
+The munger (next step) reads marking bytes from `MEDIA_ROOT/<region>/`, not from
+`wip/out/`. Copy them:
+
+```bash
+mkdir -p backend/media/va
+cp tools/wip/out/VA_ASCC_CTLG_images/*.png backend/media/va/
+```
+
+## F. Munge  (deterministic, no API)
+
+Point `--input` at the extract CSV in `out/`, `--input-dir` at the seeds in `in/`
+(avoids copying the CSV back into `in/`):
+
+```bash
+uv run python tools/ascc_data_munger.py \
+  --input tools/wip/out/VA_ASCC_CTLG.csv \
+  --input-dir tools/wip/in
+```
+
+Writes the full Django-shape CSV set to `wip/out/`: colors (16), letterings (9),
+shapes (16), regions (58, passthrough), reference_works (1, passthrough),
+post_offices (1057), post_office_regions (1057), markings (2813), dates_seen
+(3443), citations (2813), images (276), plus `marking_lineage.csv` sidecar.
+
+> **Town-heading date parsing:** see DECISIONS.md — a local patch to
+> `tools/munger/head.py` (`parse_head`) is required to strip bare trailing
+> years off town-table headings (`Accomack C.H 1835` → `Accomack C.H`).
+> Without it the munger aborts with "PostOffice normalization produced N
+> name(s) with characters outside [A-Z, space, period, single dash]."
+
+## G. Import  (deterministic, no API)
+
+```bash
+uv run python backend/manage.py import_ascc_bundle ./tools/wip/out/
+```
+
+Loads in FK-safe order (colors → letterings → shapes → regions →
+reference_works → post_offices → post_office_regions → markings → … →
+citations → images). `covers / cover_valuations / cover_markings` are absent for
+this catalog and are skipped. The whole bundle is one transaction — any error
+rolls everything back (no partial state).
+
+**Pre-reqs the bundle needs in the DB (one-time):**
+
+1. **A user with `id=1`.** Every row's `created_by/modified_by` references user 1.
+   ```bash
+   uv run python backend/manage.py shell -c "from django.contrib.auth import get_user_model as G; U=G(); U.objects.filter(id=1).exists() or U(id=1,username='admin',is_superuser=True,is_staff=True).save()"
+   ```
+2. **Schema fixes for `staging` migration drift** — see DECISIONS.md "staging
+   fresh-install schema is incomplete." On a fresh `staging` DB these four are
+   needed before the import succeeds (local DB only; the real fix is Michael's
+   migrations):
+   ```sql
+   ALTER TABLE post_office MODIFY region_id BIGINT NULL;   -- orphaned NOT NULL col
+   ALTER TABLE images DROP INDEX storage_filename;          -- model says NOT unique
+   ```
+   ```python
+   # create 4 model-declared tables 0001_initial never built, + images.is_tracing:
+   from django.db import connection; from django.apps import apps
+   from common.models import Image
+   with connection.schema_editor() as se:
+       for n in ['PostOfficeRegion','CoverVersion','MarkingRecycleBin','CoverRecycleBin']:
+           se.create_model(apps.get_model('common', n))
+       se.add_field(Image, Image._meta.get_field('is_tracing'))
+   ```
+
+Result (VA): **`Done. new=11559  update=0  skip=0  invalid=0  error=0`**
+(post_offices 1057, post_office_regions 1057, markings 2813, dates_seen 3443,
+citations 2813, images 276, + 58 auto-created Collections).
+
+---
+
+## Verify
+
+1. `./woco dev`, open `http://localhost:8080`.
+2. Search for a Virginia marking; confirm the listing AND its marking image render.
+
+Verified for VA at the API/media layer (what the search page consumes):
+
+```bash
+curl -s http://localhost:8000/api/v2/markings/1/ | python3 -m json.tool   # state VA, region Virginia, 1 image w/ image_url
+curl -s -o /dev/null -w '%{http_code} %{content_type}\n' \
+  http://localhost:8000/media/va/va-419-2-1.png                            # 200 image/png
+```
+
+`/api/v2/markings/?page=1` returns `count: 2813`; post-office names are clean
+(0 digit-bearing names; `ACCOMACK`, `ACCOMACK C.H` present).
+
+---
+
+## Gotchas found while validating VA
+
+- **`.env` location:** scripts read `worldcovers/.env`, not the workspace-root `.env`.
+- **Free-tier OpenRouter** keys (no credit) 402 on the paid vision model. Use a funded key.
+- **`pdftoppm`** must be on PATH (poppler). No-sudo option: `brew install poppler`.
+- **Three file-hops:** chunks `out/<BASE>/` → `in/<BASE>/` (hop 1); marking images
+  `out/<BASE>_images/` → `backend/media/<region>/` (hop 2); the munger can read the
+  extract CSV from `out/` directly via `--input` + `--input-dir`.
+- **`reference_works.csv` ships with 2 rows** (ASCC1 + ASCC2); the munger requires
+  exactly 1. For the VA baseline we keep ASCC1 (the published 5th edition the scan
+  is from). See DECISIONS.md.
+- **`main` branch** can't migrate a fresh DB (`InvalidBasesError`); use `staging`.
+- **`staging` migrates but the schema is incomplete** (4 drifts) — see the Stage G
+  pre-reqs and DECISIONS.md. This is the single biggest blocker to a clean repro and
+  is Michael's to fix at the migration level.
+
+## Summary of changes this runbook depends on
+
+| Change | Where | Status |
+|--------|-------|--------|
+| `parse_head` town-heading date peel | `tools/munger/head.py` (code) | local patch, branch `reese/issue-1-va-e2e`, **proposed to Michael** |
+| 4 schema fixes + user id=1 | local MySQL only | local workaround; **Michael fixes migrations** |
+| chunk-14 `Images Above` correction | scratch CSV | per-chunk review (expected workflow) |
+| keep ASCC1 in `reference_works.csv` | scratch seed | baseline choice |

--- a/tools/ascc_data_munger.py
+++ b/tools/ascc_data_munger.py
@@ -28,7 +28,12 @@ from munger.fields.rates import RATE_BRACKET_RE, parse_rate_token, split_rate_to
 from munger.fields.sizes import parse_size_field
 from munger.head import parse_head, parse_manuscript_row
 from munger.images import MEDIA_ROOT
-from munger.io import OPTIONAL_COLS, REQUIRED_COLS, process_meta_rows
+from munger.io import (
+    OPTIONAL_COLS,
+    REQUIRED_COLS,
+    assign_section_regions,
+    process_meta_rows,
+)
 from munger.rate_assembly import BRACKET_DIM_RE, BRACKET_SHAPE_MAP, _date_cls, _tm_codes_by_listing, parse_rate_amount
 from munger.relationships import OR_ALIAS_RE, TOWN_HEADING_RE, _is_abbrev_of, _norm_for_alias, resolve_relationships, roll_up_catalog_text
 from munger.segment import classify_entry_form, decompose_tail, segment_entry, split_paren_fields, split_valuation_tiers
@@ -78,6 +83,7 @@ def main(argv=None):
         raise ValueError(
             f'Required columns missing from {INPUT_CSV}: {missing_required}'
         )
+    df['section_region_id'] = assign_section_regions(df, _region_seed, REGION_ID)
     meta_df = df[df['Type'] == 'META'].reset_index(drop=True)
     listings_df = df[df['Type'] == 'LISTING'].reset_index(drop=True)
     process_meta_rows(meta_df)
@@ -1824,15 +1830,43 @@ def main(argv=None):
             lambda sc: unknown_by_state[_nkey(sc)]
         ).values
         print(f'  Assigned {unresolved.sum()} townmarks to UNKNOWN post office(s) across {len(unknown_by_state)} state(s)')
+    # One junction row per distinct (post office, section region) pair: a
+    # post office listed under several catalog sections (e.g. Detroit under
+    # Northwest Territory, Indiana Territory, Michigan Territory, and
+    # statehood) links to each of those regions. POs with no listing-derived
+    # pair (the UNKNOWN fallbacks) get the catalog default region.
+    _po_region_pairs = (
+        listings[['post_office_id', 'section_region_id']]
+        .dropna()
+        .astype(int)
+        .drop_duplicates()
+        .rename(columns={'section_region_id': 'region_id'})
+    )
+    _covered_pos = set(_po_region_pairs['post_office_id'])
+    _uncovered = [
+        {'post_office_id': int(pid), 'region_id': REGION_ID}
+        for pid in post_offices_df['post_office_id']
+        if int(pid) not in _covered_pos
+    ]
+    if _uncovered:
+        _po_region_pairs = pd.concat(
+            [_po_region_pairs, pd.DataFrame(_uncovered)], ignore_index=True
+        )
+    _po_region_pairs = (
+        _po_region_pairs
+        .sort_values(['post_office_id', 'region_id'])
+        .reset_index(drop=True)
+    )
     post_office_regions_df = pd.DataFrame({
-        'post_office_region_id': range(1, len(post_offices_df) + 1),
-        'post_office_id': post_offices_df['post_office_id'].astype(int).values,
-        'region_id': REGION_ID,
+        'post_office_region_id': range(1, len(_po_region_pairs) + 1),
+        'post_office_id': _po_region_pairs['post_office_id'].astype(int).values,
+        'region_id': _po_region_pairs['region_id'].astype(int).values,
     })
     print(f'PostOffice records: {len(post_offices_df)}')
     print(f'  From {listings["resolved_town"].nunique()} raw distinct towns')
     print(f'  To {len(post_offices_df)} normalized post offices')
-    print(f'PostOfficeRegion links: {len(post_office_regions_df)} (all -> region_id={REGION_ID})')
+    print(f'PostOfficeRegion links: {len(post_office_regions_df)} '
+          f'across {post_office_regions_df["region_id"].nunique()} region(s)')
     if post_offices_df['state_code'].notna().any():
         per_state = post_offices_df.groupby('state_code').size()
         print(f'  Per state:')

--- a/tools/munger/head.py
+++ b/tools/munger/head.py
@@ -105,6 +105,47 @@ def parse_head(row):
 
     # 5. Name body: head text with annotation parens removed, stripped
     name_body = PAREN_GROUP_RE.sub('', head).strip()
+
+    # 5b. Peel a bare trailing date field off town-table headings.
+    #     Town-listing rows print as "NAME .... YEAR(S) .... VALUE" with
+    #     dot-leader separators (ascc_page_extract compresses the leaders
+    #     to "..."). strip_dot_leaders flattens those to spaces before
+    #     segmentation, so once segment_entry removes the trailing value
+    #     the head arrives here as e.g. "Accomack C.H 1835",
+    #     "Aquia 1811,1849-55", or "Arbor Hill 1850's" -- the year is
+    #     glued to the town name. parse_manuscript_row already peels this
+    #     for Manuscript-flagged rows; reuse its exact loop (date, then
+    #     dash placeholder, then trailing separators) so the normal
+    #     (non-manuscript) path normalizes identically. The dash/sep peels
+    #     also clear a "--/" residue left on the head when a slash-tiered
+    #     value like "--/15.00" is only partly consumed by segment_entry,
+    #     which otherwise hides the date from MS_DATE_AT_END's end-anchor.
+    #     No-op for rows whose dates were parenthesized annotations (those
+    #     were removed in step 5), so manuscript-section parsing is
+    #     unchanged.
+    if name_body:
+        while True:
+            m_date = MS_DATE_AT_END.search(name_body)
+            if m_date:
+                name_body = name_body[:m_date.start()].rstrip()
+                continue
+            m_dash = MS_DASH_AT_END.search(name_body)
+            if m_dash:
+                name_body = name_body[:m_dash.start()].rstrip()
+                continue
+            m_sep = MS_SEP_AT_END.search(name_body)
+            if m_sep:
+                name_body = name_body[:m_sep.start()].rstrip()
+                continue
+            break
+
+    # 5c. Drop residues with no real town text (e.g. a row that was just a
+    #     bare year like "1849"): they would otherwise become a PostOffice
+    #     name made only of digits and fail downstream normalization. A
+    #     None town routes the row to the UNKNOWN post office instead.
+    if name_body and not re.search(r'[A-Za-z]{2,}', name_body):
+        name_body = None
+
     name_body = name_body if name_body else None
 
     return pd.Series({

--- a/tools/munger/io.py
+++ b/tools/munger/io.py
@@ -1,3 +1,5 @@
+import re
+
 import pandas as pd
 
 
@@ -5,8 +7,85 @@ REQUIRED_COLS = ['Listing', 'Page', 'Chunk', 'Images Above', 'Type']
 
 OPTIONAL_COLS = ['Manuscript', 'Default Shape', 'Institutional Ownership']
 
+_WS = re.compile(r'\s+')
+
+# Unmatched-banner report: all-caps META lines that look like section
+# headings (so a misread banner shows up in the verify step instead of
+# silently leaving its listings on the catalog default region).
+_BANNER_CANDIDATE = re.compile(r"[A-Z][A-Z .,'&-]{3,40}")
+
+
+def _norm_banner(text) -> str:
+    return _WS.sub(' ', str(text)).strip().upper()
+
+
+def assign_section_regions(df, region_seed, default_region_id: int) -> pd.Series:
+    """Per-listing region id derived from the catalog section each row
+    sits under, walking rows in CSV (reading) order and tracking the
+    active section across META banner rows.
+
+    Only TERRITORY-tier region names switch the active section -- the
+    catalog's section banners ("MICHIGAN TERRITORY", optionally prefixed
+    "AS NORTHWEST TERRITORY") name the territory in force, while town
+    strings only carry abbreviations like "M.T." that the ASCC header
+    explicitly calls ambiguous (Michigan / Minnesota / Mississippi
+    Territory). A banner containing STATEHOOD resets to
+    default_region_id. Bare state names never match: the page running
+    head (e.g. "MICHIGAN") survives extraction as a META row on every
+    page and must not reset the section.
+
+    Returns an int64 Series aligned to df.index. Catalogs without
+    territory banners (e.g. VA) come back all default_region_id.
+    """
+    territory_by_name = {
+        _norm_banner(row['name']): int(row['id'])
+        for _, row in region_seed.iterrows()
+        if str(row.get('region_tier', '')).strip().upper() == 'TERRITORY'
+    }
+    region_name_by_id = {
+        int(row['id']): str(row['name']) for _, row in region_seed.iterrows()
+    }
+
+    current = int(default_region_id)
+    assigned = []
+    switches = []
+    unmatched = {}
+    for _, row in df.iterrows():
+        if row['Type'] == 'META':
+            banner = _norm_banner(row['Listing'])
+            key = banner[3:] if banner.startswith('AS ') else banner
+            if key in territory_by_name:
+                current = territory_by_name[key]
+                switches.append((banner, current))
+            elif 'STATEHOOD' in banner:
+                current = int(default_region_id)
+                switches.append((banner, current))
+            elif _BANNER_CANDIDATE.fullmatch(banner):
+                unmatched[banner] = unmatched.get(banner, 0) + 1
+        assigned.append(current)
+
+    out = pd.Series(assigned, index=df.index, dtype='int64')
+
+    listing_mask = df['Type'] == 'LISTING'
+    counts = out[listing_mask].value_counts().sort_index()
+    print('Section-region assignment:')
+    for region_id, n in counts.items():
+        name = region_name_by_id.get(int(region_id), '?')
+        print(f'  region {int(region_id)} ({name}): {int(n)} listings')
+    if switches:
+        print(f'  Section switches ({len(switches)}):')
+        for banner, region_id in switches:
+            print(f'    {banner!r} -> region {region_id}')
+    if unmatched:
+        print('  Unmatched banner-like META rows (verify none is a real section):')
+        for banner, n in sorted(unmatched.items(), key=lambda kv: -kv[1])[:15]:
+            print(f'    {banner!r} x{n}')
+    return out
+
+
 def process_meta_rows(meta_df):
-    # TODO: parse META rows for section-heading / state-heading context,
-    # column headers, and cross-reference targets. Inputs: meta_df with
-    # columns Listing, Page, Chunk, Images Above, Type. Currently a no-op.
+    # TODO: parse META rows for column headers and cross-reference
+    # targets. Inputs: meta_df with columns Listing, Page, Chunk,
+    # Images Above, Type. Section/state-heading context is handled by
+    # assign_section_regions(). Currently a no-op.
     return None

--- a/tools/test_munger_sections.py
+++ b/tools/test_munger_sections.py
@@ -1,0 +1,86 @@
+"""Tests for section-driven region assignment (munger.io).
+
+Run from repo root:
+    .venv/bin/python -m unittest discover -s tools -p 'test_munger_sections.py'
+
+Expected exit code: 0.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+TOOLS_DIR = Path(__file__).resolve().parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+from munger.io import assign_section_regions
+
+REGION_SEED = pd.DataFrame([
+    {'id': 1,  'name': 'United States of America', 'region_tier': 'COUNTRY'},
+    {'id': 25, 'name': 'Michigan',                 'region_tier': 'STATE'},
+    {'id': 36, 'name': 'Northwest Territory',      'region_tier': 'TERRITORY'},
+    {'id': 51, 'name': 'Virginia',                 'region_tier': 'STATE'},
+    {'id': 59, 'name': 'Michigan Territory',       'region_tier': 'TERRITORY'},
+    {'id': 60, 'name': 'Indiana Territory',        'region_tier': 'TERRITORY'},
+])
+
+
+def _df(rows):
+    return pd.DataFrame(rows, columns=['Listing', 'Type'])
+
+
+class TestAssignSectionRegions(unittest.TestCase):
+
+    def test_michigan_catalog_sections(self):
+        df = _df([
+            ('MICHIGAN', 'META'),                       # state heading
+            ('BRITISH COLONIAL PERIOD', 'META'),        # no region -> default
+            ('"Detroit 30 May 1769" dateline', 'LISTING'),
+            ('AS NORTHWEST TERRITORY', 'META'),
+            ('*Detroit*(Feb. 14, 1792;SL-21x3,MDD;Black)', 'LISTING'),
+            ('AS INDIANA TERRITORY', 'META'),
+            ('Detroit(E)(June 1, 1803;Ms;Black) 1750', 'LISTING'),
+            ('MICHIGAN TERRITORY', 'META'),
+            ('Ann Arbor M.T.(E)(1825;Ms;Black)', 'LISTING'),
+            ('MICHIGAN', 'META'),                       # running head mid-section
+            ('Green Bay M.T.(1825;Ms;Black)', 'LISTING'),
+            ('STATEHOOD PERIOD', 'META'),
+            ('ADRIAN/MIC.(1838;C-30;Black)', 'LISTING'),
+            ('MANUSCRIPT TOWN MARKS', 'META'),
+            ('SCHOOLCRAFT/Mich.(1838-52;30;Black)', 'LISTING'),
+        ])
+        out = assign_section_regions(df, REGION_SEED, default_region_id=25)
+        listing_regions = out[df['Type'] == 'LISTING'].tolist()
+        self.assertEqual(listing_regions, [25, 36, 60, 59, 59, 25, 25])
+
+    def test_running_head_does_not_reset_territory_section(self):
+        # Load-bearing: the bare state name survives extraction as META on
+        # every page; matching it would silently end the territory section.
+        df = _df([
+            ('MICHIGAN TERRITORY', 'META'),
+            ('Pontiac M.T.(1830;Ms;Black)', 'LISTING'),
+            ('MICHIGAN', 'META'),
+            ('Saginaw M.T.(1835;Ms;Black)', 'LISTING'),
+        ])
+        out = assign_section_regions(df, REGION_SEED, default_region_id=25)
+        self.assertEqual(out[df['Type'] == 'LISTING'].tolist(), [59, 59])
+
+    def test_catalog_without_territory_banners_is_all_default(self):
+        # VA-shaped input: nothing matches, every listing keeps the
+        # filename-derived region (regression guard for existing catalogs).
+        df = _df([
+            ('VIRGINIA', 'META'),
+            ('Town Postmark Dates Seen Size Color Value', 'META'),
+            ('Accomack C.H(1835;Ms;Black)', 'LISTING'),
+            ('MANUSCRIPT TOWN MARKS', 'META'),
+            ('AQUIA/Va.(1849-55;30;Black)', 'LISTING'),
+        ])
+        out = assign_section_regions(df, REGION_SEED, default_region_id=51)
+        self.assertEqual(out[df['Type'] == 'LISTING'].tolist(), [51, 51])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Proposal branch from Reese — three commits from reproducing VA end-to-end and preparing the Michigan catalog's pre-statehood (territory) markings. Nothing here is merged anywhere; opening as draft for review.

## What's in the diff

1. **`8be62ca` fix(munger):** strip bare trailing dates off town-table headings in `parse_head` (`Accomack C.H 1835` → `Accomack C.H`). Required for VA to munge at all — 752 post-office names otherwise fail the digit assertion. Reuses your existing `MS_DATE_AT_END`/`MS_DASH_AT_END`/`MS_SEP_AT_END` regexes, so manuscript-section behavior is unchanged. Caveat: it *drops* the peeled year, which intersects the "Years Seen" question — flagged in the report.
2. **`59fe014` docs:** `docs/PIPELINE.md` — the step-by-step ASCC pipeline runbook, validated by running VA E2E locally (11,559 rows, 0 import errors).
3. **`0bf714b` feat(munger):** section-driven region assignment. Listings take the region of the catalog section banner above them (TERRITORY-tier `regions.csv` names, optional `AS ` prefix; `STATEHOOD` resets to the catalog default; bare state names ignored — the page running head survives extraction as META on every page). `post_office_regions` now emits one row per distinct (post office, region) pair, so Detroit links to each region it operated under. Implements the section-heading half of the `process_meta_rows` TODO. 3 unit tests; re-munging VA is byte-identical modulo run timestamps.

## Not in the diff (proposed, awaiting your OK)

Two `regions.csv` rows, currently only in gitignored scratch:

| id | name | tier | parent | established | defunct |
|---|---|---|---|---|---|
| 59 | Michigan Territory | TERRITORY | 1 | 1805-06-30 | 1837-01-26 |
| 60 | Indiana Territory | TERRITORY | 1 | 1800-07-04 | 1816-12-11 |

Abbrevs left empty deliberately — the catalog only uses the ambiguous `M.T.` (your header doc: Michigan/Minnesota/Mississippi), and the eventual codes must not collide with 2-char state abbrevs since the munger keys catalogs to regions by filename prefix.

## Open questions

Full write-up with v1 evidence and the open-items list is in Reese's report (sent separately): abbrev codes, blessing the region rows into the canonical seed + DB, territory search/UI parenting, fresh-install schema drifts, and VA+MI PK coexistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)