### PR TITLE
Michigan pre-statehood: section-driven region assignment + VA pipeline fixes

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -2,15 +2,17 @@
 
 **Single source of truth for engineering work on WorldCovers (WoCo) / APMC.**
 This file merges every WoCo issue we currently track, from all sources, into one
-list so there is exactly one place to look. It supersedes the scattered set:
+list so there is exactly one place to look.
 
 | Source | What it was | Folded in here as |
 |---|---|---|
 | `06-09-emails.md` (Ian Gibson-Smith, Greg Stone) | Raw beta feedback + change requests | Issues **1–27** |
-| `ISSUES.md` / `trello_cards_based_on_issues.md` | First pass numbering of those emails | Issues **1–27** (renumbered cleanly, see note) |
 | Reese's working queue (`docs/issues.md`) | Pipeline milestones M1–M3 | Tagged **[R1]–[R8]** inline |
-| `HDC2qwhi` Trello board export | Live engineering board (`F1–F11 / S0–S49`) | Cross-referenced per issue + appendix |
 | `docs/DECISIONS.md`, `docs/mi-edge-cases.md`, `docs/michigan-report-for-michael.md` | Michigan E2E status + open calls | Status + Issues **28–34** |
+
+Issues are numbered **1–34**, no prefixes. The earlier `ISSUES.md` /
+`trello_cards_based_on_issues.md` pass and the Trello board are being retired in
+favor of this file.
 
 **Scope:** WorldCovers / APMC only. IanThom.org and ChinaOverprints (and the
 Bluehost/Porkbun account admin) are a separate, lower-precedence track and are
@@ -23,20 +25,6 @@ deliberately omitted here.
 ASCC = the first catalog being digitized into APMC. USPCS = U.S. Philatelic
 Classics Society (sponsor). VAPHS = Virginia Postal History Society catalog.
 v1 = the legacy ColdFusion/MSSQL system behind worldcovers.org (`worldcovers-v1/`).
-
----
-
-## ⚠️ Numbering note — two `S#/T#` schemes collide
-
-`trello_cards_based_on_issues.md` invented its own `S1/T2/T3/…` numbering for the
-email issues. **That scheme collides with the live Trello board**, where `S5`,
-`T1`–`T6`, etc. already mean *different, real* cards (e.g. board `S5` = "Export
-records in supported formats"; board `T1` = "Punch up developer documentation").
-
-**Resolution adopted here:** the email-derived issues are numbered **1–27** with
-**no `S/T` prefix**. `S#`/`T#`/`F#` are reserved exclusively for the live board.
-The ad-hoc scheme in `trello_cards_based_on_issues.md` should be retired so it
-can't clobber board cards.
 
 ---
 
@@ -63,12 +51,11 @@ earlier broken-`main` migrate against the same DB. Migration-integrity alarm
 # Issues
 
 Status values: `open` · `in-progress` · `blocked` · `done`.
-"Board:" links the live Trello feature/card where one exists.
 
 ## Data & ingestion
 
 ### Issue 1 — Fix WV data ingestion ("WV disconnect")
-**Status:** open · **Depends on:** none · **Board:** F11 Catalog Data Pipeline / F2 Collection Discovery
+**Status:** open · **Depends on:** none
 West Virginia markings don't appear in listings — Martinsburg and Shepherdstown
 are entirely absent, and Ian's own markings don't show. Ian: add WV **asap**.
 - [ ] Martinsburg, WV markings appear in listings
@@ -77,7 +64,7 @@ are entirely absent, and Ian's own markings don't show. Ian: add WV **asap**.
 - [ ] Root cause documented: import gap vs. query/filter bug
 
 ### Issue 2 — Fix Richmond town-name normalization
-**Status:** open · **Depends on:** none · **Board:** F11
+**Status:** open · **Depends on:** none
 Records render the town as `Richmd, VA` instead of "Richmond" — unsearchable and
 looks broken to beta testers. (Same *family* of head-parsing normalization as the
 Michigan territory-suffix residue, Issue 28.)
@@ -85,7 +72,7 @@ Michigan territory-suffix residue, Issue 28.)
 - [ ] Searching "Richmond, VA" returns those markings
 
 ### Issue 3 — Stampless parser: unknown year misread as rate (Amelia, VA)
-**Status:** open · **Depends on:** none · **Board:** F11 · **Source:** Greg Stone
+**Status:** open · **Depends on:** none · **Source:** Greg Stone
 When the catalog year is unknown (`—`), the parser uses the CDS/circle **size** as
 a rate marking. Systematic corruption of imported VA records.
 - [ ] Amelia, VA no longer shows the CDS size as a rate
@@ -93,27 +80,27 @@ a rate marking. Systematic corruption of imported VA records.
 - [ ] Spot-check of other unknown-year VA entries confirms the fix
 
 ### Issue 4 — Marking-shape parsing: circle imported as straight-line (New Glasgow)
-**Status:** open · **Depends on:** none · **Board:** F11 · **Source:** Greg Stone
+**Status:** open · **Depends on:** none · **Source:** Greg Stone
 Markings shown as circles in the Stampless catalog import as straight-line.
 - [ ] New Glasgow imports with the correct circular shape
 - [ ] Spot-check confirms catalog circles aren't imported as straight-line
 
 ### Issue 5 — Import updated VA data from worldcovers.org
-**Status:** in-progress (Michael) · **Depends on:** none · **Board:** F11
+**Status:** in-progress (Michael) · **Depends on:** none
 Bring the updated Virginia records from worldcovers.org into WoCo. VA is first in
 the rollout and the basis for beta testing and the VAPHS comparison.
 - [ ] VA records from worldcovers.org present in the new system
 - [ ] Record counts reconcile between source and target
 
 ### Issue 6 — Compare and import VAPHS Catalog (VA)
-**Status:** open · **Depends on:** 5 · **Board:** F11 / F6 Reference Work Management
+**Status:** open · **Depends on:** 5
 Diff the VAPHS Catalog against WoCo's VA data, then import VAPHS VA entries.
 - [ ] Diff of VAPHS vs. WoCo VA produced
 - [ ] VAPHS entries imported with `VAPHS Catalog 1st Edition` as reference work (Issue 13)
 - [ ] Duplicates reconciled, not double-listed
 
 ### Issue 7 — Enter Michigan data — ✅ DONE
-**Status:** done (pipeline) · **Depends on:** none · **Assigned:** Reese [R2] · **Board:** F11 · **PR #50**
+**Status:** done (pipeline) · **Depends on:** none · **Assigned:** Reese [R2] · **PR #50**
 Michigan imported E2E: **10,224 rows, 0 errors** (2,617 markings, 837 post
 offices, 93 images), verified at API/media. Section-driven region assignment
 validated live (Detroit → 4 regions; Michigan Territory carries 292 POs incl.
@@ -132,14 +119,14 @@ Track ingestion order VA → WV → MI → MD → FL → TN → AL with current 
 ## Bugs & cleanup
 
 ### Issue 9 — Editor dashboard: delete bad records
-**Status:** open · **Depends on:** none · **Board:** F3 Submission Workflow
+**Status:** open · **Depends on:** none
 Delete the folded-cover record dated `1864-01-01` (submitted by Ian, missing
 image) and the other fake submission Ian rejected.
 - [ ] `1864-01-01` folded-cover record removed
 - [ ] Rejected fake submission removed
 
 ### Issue 10 — Submitter edit/revise permission bug
-**Status:** open · **Depends on:** none · **Board:** F1 Authentication / F3
+**Status:** open · **Depends on:** none
 Authenticated editor (repro: Wayne Farley) could not revise/reject their own
 pending listing — *"not authorized to reject or revise anything."* Michael's manual
 user-ID fix suggests a **systemic permissions gap after account migration** from
@@ -149,7 +136,7 @@ worldcovers.org.
 - [ ] Regression: no editor sees a spurious "not authorized" on their own records
 
 ### Issue 11 — Submit New Cover: set the main image marking (Prospect Hill bug)
-**Status:** open · **Depends on:** none · **Board:** F5 Image Attachments · related **[R3]**
+**Status:** open · **Depends on:** none · related **[R3]**
 A newly added cover can't be designated the main image for its marking
 (reproduced by Ian on Prospect Hill). Editors can't control which image
 represents a marking. Backend (`ImageViewSet`/`ImageResource`) exists — overlaps
@@ -160,7 +147,7 @@ the [R3] `SubmitImageDialog.tsx` → `/api/v2/images/` wiring.
 ## UI copy & forms
 
 ### Issue 12 — Canonical submission-guidelines content block
-**Status:** open · **Depends on:** none · **Board:** F9 Documentation & Help
+**Status:** open · **Depends on:** none
 One reusable guidelines block (used on three submission pages — define once):
 1. Image quality — "300 dpi preferred"
 2. Rate vs. Auxiliary — *Rate: "Paid", "Free", "3", "Due 3"; Auxiliary: "Advertised", "Missent"* (final wording gated on Issue 21)
@@ -170,7 +157,7 @@ One reusable guidelines block (used on three submission pages — define once):
 - [ ] Content approved against Ian's wording
 
 ### Issue 13 — Submit New Marking page updates
-**Status:** open · **Depends on:** 12 · **Board:** F3 / F6
+**Status:** open · **Depends on:** 12
 - [ ] Rename "Create Marking" → **"Submit New Marking"**
 - [ ] Expose **ERD** (Earliest Recorded Date) and **LRD** (Latest Recorded Date) fields
 - [ ] Reference Works lists **"ASCC Edition 5", "ASCC Edition 6", "VAPHS Catalog 1st Edition"** (currently shows ASCC twice — remove dup)
@@ -178,7 +165,7 @@ One reusable guidelines block (used on three submission pages — define once):
 - [ ] Townmark field: hover/bracket note that it means the **EXACT** text on the marking
 
 ### Issue 14 — Submit Edit to Marking page updates
-**Status:** open · **Depends on:** 12 · **Board:** F3
+**Status:** open · **Depends on:** 12
 - [ ] Rename "Edit Marking" → **"Submit Edit to Existing Marking"**
 - [ ] Date-format selector: "Select one or more date formats" → **"Select Date format"** (single-select)
 - [ ] Document date-format codes: **MD** (month/day), **MDD** (month and day), **YMD** (year and month), **YMDD** (year, month and day) — ⚠️ *source listed "YMDD" twice; confirm the year-and-month code with Ian*
@@ -186,15 +173,15 @@ One reusable guidelines block (used on three submission pages — define once):
 - [ ] Apply guidelines block (Issue 12)
 
 ### Issue 15 — Submit New Cover page updates
-**Status:** open · **Depends on:** 12 · **Board:** F3 / F5
+**Status:** open · **Depends on:** 12
 - [ ] Apply guidelines block (Issue 12), including the date-verification-image note
 
 ### Issue 16 — Rename "Record Details" → "Cover Details"
-**Status:** open · **Depends on:** none · **Board:** F2
+**Status:** open · **Depends on:** none
 - [ ] Screen header + all nav/labels read **"Cover Details"**
 
 ### Issue 17 — Submitter acknowledgement on covers
-**Status:** open · **Depends on:** 16 · **Board:** F3 / F5 · related **[R8]**
+**Status:** open · **Depends on:** 16 · related **[R8]**
 On **Submit New Cover** (covers only, **not** markings): "Would you like your
 name to display as the submitter?" If yes → show "Submitted by [name]" on the
 Cover Details screen. Incentivizes uploads.
@@ -204,21 +191,21 @@ Cover Details screen. Incentivizes uploads.
 - [ ] Option does **not** appear on marking submission
 
 ### Issue 18 — Catalog Search: search by size (diameter)
-**Status:** open · **Depends on:** none · **Board:** F2 Collection Discovery
+**Status:** open · **Depends on:** none
 - [ ] Catalog Search exposes a size/diameter filter
 - [ ] Searching by diameter returns matching markings
 
 ## Markings model & display (Greg Stone parsing feedback)
 
 ### Issue 19 — Ratemark display: plain vs. in-circle rate
-**Status:** open · **Depends on:** none · **Board:** F11 · **Source:** Greg Stone
+**Status:** open · **Depends on:** none · **Source:** Greg Stone
 Show the difference between a plain rate ("5") and a rate enclosed in a circle —
 as the Stampless catalog distinguishes Cumberland vs. Curdsville.
 - [ ] A "5" and a circled "5" render distinguishably
 - [ ] Cumberland and Curdsville display their correct rate styling
 
 ### Issue 20 — "Years Seen" model for marking dates
-**Status:** open · **Depends on:** none · **Board:** F11 · **Source:** Greg Stone
+**Status:** open · **Depends on:** none · **Source:** Greg Stone
 **⚠️ Model change — scope first; record decision in `docs/DECISIONS.md`.**
 Replace the strict Earliest/Latest pair with discrete known years/ranges to handle
 hiatuses (Greg's Aquila: **1811, 1849–1855**), for both handstamp and manuscript.
@@ -231,7 +218,7 @@ which currently *drops* trailing years this model would want to preserve.**
 - [ ] **Decision recorded in DECISIONS.md**
 
 ### Issue 21 — Rate vs. Auxiliary classification decision
-**Status:** open · **Depends on:** 12 · **Board:** F11 · **Source:** Greg Stone
+**Status:** open · **Depends on:** 12 · **Source:** Greg Stone
 **⚠️ Board decision; record in `docs/DECISIONS.md`.**
 Keep Ratemarks as a distinct class, or treat all non-townmarks as Auxiliary
 (Greg's proposal: "Paid" and "Paid 5" both Auxiliary)? Ian: *"a marking is a
@@ -243,7 +230,7 @@ marking at the end of the day"* — wants a board ruling before conventions hard
 ## Content, branding & citations
 
 ### Issue 22 — Rewrite the Acknowledgements page
-**Status:** open · **Depends on:** none · **Board:** F9
+**Status:** open · **Depends on:** none
 Replace with Ian's supplied copy (sections: U.S. Philatelic Classics Society,
 Project Team, Beta Testers, Past Editors of the Catalogue, Donors). Full verbatim
 text in `06-09-emails.md` → "Acknowledgements" thread, and drafted at
@@ -252,7 +239,7 @@ text in `06-09-emails.md` → "Acknowledgements" thread, and drafted at
 - [ ] All named people/orgs match the email exactly (spelling verified)
 
 ### Issue 23 — Branding: APMC + Classics Society
-**Status:** open · **Depends on:** none · **Board:** F2 · related **[R7]**
+**Status:** open · **Depends on:** none · related **[R7]**
 **⚠️ Board approval required before merge.**
 Replace "Worldcovers" branding with **APMC**, add the U.S. Philatelic Classics
 Society logo, and add Society website / "Become a member" links.
@@ -261,7 +248,7 @@ Society logo, and add Society website / "Become a member" links.
 - [ ] Final branding/logo/links confirmed with the board before merge
 
 ### Issue 24 — Per-state reference citations
-**Status:** open · **Depends on:** 13 · **Board:** F6 Reference Work Management
+**Status:** open · **Depends on:** 13
 As each state is added, attach its source reference/citation (e.g. VAPHS Catalog) —
 listings from another catalog are accepted as genuine on that catalog's authority.
 - [ ] Imported listings carry their source reference work
@@ -270,7 +257,7 @@ listings from another catalog are accepted as genuine on that catalog's authorit
 ## Lower priority / later
 
 ### Issue 25 — Marking with multiple states/territories
-**Status:** open · **Depends on:** none · **Board:** F11 · related **[R5]**
+**Status:** open · **Depends on:** none · related **[R5]**
 Support and display a single marking belonging to more than one state/territory.
 **Spike already answered by the Michigan run:** the `post_office_regions` junction
 is **already many-to-many** (`unique_together [post_office, region]`); Detroit
@@ -280,13 +267,13 @@ is largely **display + filter UI**, not a schema change. See Issue 31.
 - [ ] Detail screen displays all associated states
 
 ### Issue 26 — Submit a cover for additional markings
-**Status:** open · **Depends on:** none · **Board:** F3 / F5
+**Status:** open · **Depends on:** none
 After a cover is submitted for one marking, allow associating it with another
 marking without re-uploading (many covers carry multiple markings).
 - [ ] From a submitted cover, user can associate it with another marking without re-uploading
 
 ### Issue 27 — Submitter self-delete option (open question)
-**Status:** open · **Depends on:** none · **Board:** F3
+**Status:** open · **Depends on:** none
 **⚠️ Decision required.** Should submitters be able to delete their own submissions?
 - [ ] Decision recorded (yes/no) with rationale
 - [ ] If yes: submitter can delete own submission. If no: close in tracker.
@@ -388,31 +375,3 @@ to confirm MI E2E does **not** attempt it.
 - **Billing/naming** — confirm "Covercensus" == "Worldcovers" for tax/billing (pending Michael).
 - **ASCC data-model doc** — reference only (Google Doc linked in `06-09-emails.md` → "ASCC database" thread).
 - **IanThom.org / ChinaOverprints / account admin / Jay Logan transition** — separate, lower-precedence track. Not tracked here.
-
----
-
-# Appendix — Live Trello board reconciliation (`HDC2qwhi`)
-
-The live board is a feature-based story map, distinct from the email issues above.
-It is the authority for `F#/S#/T#` numbering; **don't reuse those prefixes for the
-email issues** (see the numbering note at the top).
-
-**Features:** F1 Authentication · F2 Collection Discovery · F3 Submission Workflow ·
-F4 Comment Workflow · F5 Image Attachments · F6 Reference Work Management ·
-F7 Collection Administration · F8 Audit Trail · F9 Documentation & Help ·
-F10 System Maintenance · F11 Catalog Data Pipeline.
-
-**Board state (open cards):**
-- **Doing:** `S5` Export records in supported formats (F2); `S31` Load transformed data into a running system (F11).
-- **To Do:** `T4` Basic unit tests (Jest/PyUnit); `T6` Performance testing / load balancing.
-- **Testing:** `S30` Transform catalog data from source formats, `S32` Bundle transformed data for export (F11 — **the pipeline Reese exercised for VA/MI**); plus `S6–S8, S12, S15–S20, S22–S24, S27` across F3–F10.
-- **Done:** `S0–S4, S9–S11, S13–S14, S21, S25–S26, S28–S29, S3` (auth, browse/search, submission review, backup/restore, catalog query/stats).
-- **Backlog:** `S33–S49` (tooltips, docs articles, bulk approve, notifications, tags, ratings, infinite scroll/pagination, image search, SSO/MFA, etc.) and `T1–T3, T5` (dev docs, a11y/i18n, security hardening, UI tests).
-
-**Where the email issues touch the board** (build against the corresponding feature):
-Issues 1–7, 19–20, 24 → **F11 / F6**; Issues 9–17, 26 → **F3 / F5**; Issue 18, 16, 23 → **F2**;
-Issues 10 → **F1**; Issues 12, 22 → **F9**.
-
-The email issues are mostly **new beta feedback not yet on the board** — they should
-be added as cards under the matching feature when triaged, using the board's real
-`S#/T#` sequence (next free numbers), not the ad-hoc scheme.

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -1,0 +1,418 @@
+# WorldCovers / APMC — Consolidated Issues
+
+**Single source of truth for engineering work on WorldCovers (WoCo) / APMC.**
+This file merges every WoCo issue we currently track, from all sources, into one
+list so there is exactly one place to look. It supersedes the scattered set:
+
+| Source | What it was | Folded in here as |
+|---|---|---|
+| `06-09-emails.md` (Ian Gibson-Smith, Greg Stone) | Raw beta feedback + change requests | Issues **1–27** |
+| `ISSUES.md` / `trello_cards_based_on_issues.md` | First pass numbering of those emails | Issues **1–27** (renumbered cleanly, see note) |
+| Reese's working queue (`docs/issues.md`) | Pipeline milestones M1–M3 | Tagged **[R1]–[R8]** inline |
+| `HDC2qwhi` Trello board export | Live engineering board (`F1–F11 / S0–S49`) | Cross-referenced per issue + appendix |
+| `docs/DECISIONS.md`, `docs/mi-edge-cases.md`, `docs/michigan-report-for-michael.md` | Michigan E2E status + open calls | Status + Issues **28–34** |
+
+**Scope:** WorldCovers / APMC only. IanThom.org and ChinaOverprints (and the
+Bluehost/Porkbun account admin) are a separate, lower-precedence track and are
+**not** in this file. Credentials and donor lists from the email archive are
+deliberately omitted here.
+
+**Precedence:** *"Worldcovers takes total precedence"* — Ian, 9 Jun 2026.
+
+**Glossary:** WoCo = the software. APMC = the dataset (proposed go-live brand).
+ASCC = the first catalog being digitized into APMC. USPCS = U.S. Philatelic
+Classics Society (sponsor). VAPHS = Virginia Postal History Society catalog.
+v1 = the legacy ColdFusion/MSSQL system behind worldcovers.org (`worldcovers-v1/`).
+
+---
+
+## ⚠️ Numbering note — two `S#/T#` schemes collide
+
+`trello_cards_based_on_issues.md` invented its own `S1/T2/T3/…` numbering for the
+email issues. **That scheme collides with the live Trello board**, where `S5`,
+`T1`–`T6`, etc. already mean *different, real* cards (e.g. board `S5` = "Export
+records in supported formats"; board `T1` = "Punch up developer documentation").
+
+**Resolution adopted here:** the email-derived issues are numbered **1–27** with
+**no `S/T` prefix**. `S#`/`T#`/`F#` are reserved exclusively for the live board.
+The ad-hoc scheme in `trello_cards_based_on_issues.md` should be retired so it
+can't clobber board cards.
+
+---
+
+## Status snapshot (as of 2026-06-11)
+
+**State rollout order (Ian):** VA → WV → **Michigan** → Maryland → Florida → Tennessee → Alabama.
+
+| Milestone | What | Status |
+|---|---|---|
+| **M1** | Reproduce VA E2E locally, then Michigan E2E | **Substantially done** |
+| [R1] | VA pipeline reproduced E2E locally | ✅ **DONE** — 11,559 rows, 0 errors. Required local patches (not unmodified); see `docs/DECISIONS.md`. |
+| [R2] | Michigan E2E via per-state extensibility | ✅ **DONE** — 10,224 rows, 0 errors; verified API/media. **PR #50** (this branch). Verdict: **config-only, no MI adapter class.** Open tails → Issues 28–32. |
+| M2 | Frontend gaps: user upload+verify, territory UI | Not started — Issues 11, 17, 18, 25, [R3]–[R5] |
+| M3 | QoL: citation search, branding, opt-out | Not started — Issues 22, 23, 24, [R6]–[R8] |
+
+**Highest-value finding (resolved):** the four "fresh-install schema drift" alarms
+from the VA write-up **did not reproduce** on a clean DB — they were residue of an
+earlier broken-`main` migrate against the same DB. Migration-integrity alarm
+**downgraded**. The one real remaining infra gap: `wocod` can't create
+`test_worldcovers`, so the backend test suite doesn't run locally (Issue 33).
+
+---
+
+# Issues
+
+Status values: `open` · `in-progress` · `blocked` · `done`.
+"Board:" links the live Trello feature/card where one exists.
+
+## Data & ingestion
+
+### Issue 1 — Fix WV data ingestion ("WV disconnect")
+**Status:** open · **Depends on:** none · **Board:** F11 Catalog Data Pipeline / F2 Collection Discovery
+West Virginia markings don't appear in listings — Martinsburg and Shepherdstown
+are entirely absent, and Ian's own markings don't show. Ian: add WV **asap**.
+- [ ] Martinsburg, WV markings appear in listings
+- [ ] Shepherdstown, WV markings appear in listings
+- [ ] Ian's submitted markings are findable
+- [ ] Root cause documented: import gap vs. query/filter bug
+
+### Issue 2 — Fix Richmond town-name normalization
+**Status:** open · **Depends on:** none · **Board:** F11
+Records render the town as `Richmd, VA` instead of "Richmond" — unsearchable and
+looks broken to beta testers. (Same *family* of head-parsing normalization as the
+Michigan territory-suffix residue, Issue 28.)
+- [ ] Records showing `Richmd` display as "Richmond"
+- [ ] Searching "Richmond, VA" returns those markings
+
+### Issue 3 — Stampless parser: unknown year misread as rate (Amelia, VA)
+**Status:** open · **Depends on:** none · **Board:** F11 · **Source:** Greg Stone
+When the catalog year is unknown (`—`), the parser uses the CDS/circle **size** as
+a rate marking. Systematic corruption of imported VA records.
+- [ ] Amelia, VA no longer shows the CDS size as a rate
+- [ ] Unknown-year (`—`) records import with no rate fabricated from size
+- [ ] Spot-check of other unknown-year VA entries confirms the fix
+
+### Issue 4 — Marking-shape parsing: circle imported as straight-line (New Glasgow)
+**Status:** open · **Depends on:** none · **Board:** F11 · **Source:** Greg Stone
+Markings shown as circles in the Stampless catalog import as straight-line.
+- [ ] New Glasgow imports with the correct circular shape
+- [ ] Spot-check confirms catalog circles aren't imported as straight-line
+
+### Issue 5 — Import updated VA data from worldcovers.org
+**Status:** in-progress (Michael) · **Depends on:** none · **Board:** F11
+Bring the updated Virginia records from worldcovers.org into WoCo. VA is first in
+the rollout and the basis for beta testing and the VAPHS comparison.
+- [ ] VA records from worldcovers.org present in the new system
+- [ ] Record counts reconcile between source and target
+
+### Issue 6 — Compare and import VAPHS Catalog (VA)
+**Status:** open · **Depends on:** 5 · **Board:** F11 / F6 Reference Work Management
+Diff the VAPHS Catalog against WoCo's VA data, then import VAPHS VA entries.
+- [ ] Diff of VAPHS vs. WoCo VA produced
+- [ ] VAPHS entries imported with `VAPHS Catalog 1st Edition` as reference work (Issue 13)
+- [ ] Duplicates reconciled, not double-listed
+
+### Issue 7 — Enter Michigan data — ✅ DONE
+**Status:** done (pipeline) · **Depends on:** none · **Assigned:** Reese [R2] · **Board:** F11 · **PR #50**
+Michigan imported E2E: **10,224 rows, 0 errors** (2,617 markings, 837 post
+offices, 93 images), verified at API/media. Section-driven region assignment
+validated live (Detroit → 4 regions; Michigan Territory carries 292 POs incl.
+WI/IA/MN precursors). Architecture verdict: **config-only, no Michigan adapter** —
+everything state-specific was *data*, not *code*. Entry-process notes captured in
+`docs/PIPELINE.md` for repeatability on later states.
+**Remaining tails → Issues 28–32** (territory-suffix stripping, `#N` offices,
+territory abbrevs, blessing region rows, territory search/UI).
+
+### Issue 8 — State rollout tracking
+**Status:** open · **Depends on:** none
+Track ingestion order VA → WV → MI → MD → FL → TN → AL with current status each.
+(Live status lives in the snapshot above; this issue = the standing tracker.)
+- [ ] Checklist exists with all 7 states in order + current status
+
+## Bugs & cleanup
+
+### Issue 9 — Editor dashboard: delete bad records
+**Status:** open · **Depends on:** none · **Board:** F3 Submission Workflow
+Delete the folded-cover record dated `1864-01-01` (submitted by Ian, missing
+image) and the other fake submission Ian rejected.
+- [ ] `1864-01-01` folded-cover record removed
+- [ ] Rejected fake submission removed
+
+### Issue 10 — Submitter edit/revise permission bug
+**Status:** open · **Depends on:** none · **Board:** F1 Authentication / F3
+Authenticated editor (repro: Wayne Farley) could not revise/reject their own
+pending listing — *"not authorized to reject or revise anything."* Michael's manual
+user-ID fix suggests a **systemic permissions gap after account migration** from
+worldcovers.org.
+- [ ] Editor can edit and approve their own pending/approved listing
+- [ ] Migrated accounts get correct permissions without manual intervention
+- [ ] Regression: no editor sees a spurious "not authorized" on their own records
+
+### Issue 11 — Submit New Cover: set the main image marking (Prospect Hill bug)
+**Status:** open · **Depends on:** none · **Board:** F5 Image Attachments · related **[R3]**
+A newly added cover can't be designated the main image for its marking
+(reproduced by Ian on Prospect Hill). Editors can't control which image
+represents a marking. Backend (`ImageViewSet`/`ImageResource`) exists — overlaps
+the [R3] `SubmitImageDialog.tsx` → `/api/v2/images/` wiring.
+- [ ] After adding a cover, submitter can mark it the main image
+- [ ] Chosen main image displays on the marking detail screen
+
+## UI copy & forms
+
+### Issue 12 — Canonical submission-guidelines content block
+**Status:** open · **Depends on:** none · **Board:** F9 Documentation & Help
+One reusable guidelines block (used on three submission pages — define once):
+1. Image quality — "300 dpi preferred"
+2. Rate vs. Auxiliary — *Rate: "Paid", "Free", "3", "Due 3"; Auxiliary: "Advertised", "Missent"* (final wording gated on Issue 21)
+3. Reference works — "To add a new reference, please add a note to editor for approval and addition"
+4. Date-verification — "please include image verifying date if not on exterior of cover"
+- [ ] Reusable component/string exists with all four items
+- [ ] Content approved against Ian's wording
+
+### Issue 13 — Submit New Marking page updates
+**Status:** open · **Depends on:** 12 · **Board:** F3 / F6
+- [ ] Rename "Create Marking" → **"Submit New Marking"**
+- [ ] Expose **ERD** (Earliest Recorded Date) and **LRD** (Latest Recorded Date) fields
+- [ ] Reference Works lists **"ASCC Edition 5", "ASCC Edition 6", "VAPHS Catalog 1st Edition"** (currently shows ASCC twice — remove dup)
+- [ ] Apply guidelines block (Issue 12)
+- [ ] Townmark field: hover/bracket note that it means the **EXACT** text on the marking
+
+### Issue 14 — Submit Edit to Marking page updates
+**Status:** open · **Depends on:** 12 · **Board:** F3
+- [ ] Rename "Edit Marking" → **"Submit Edit to Existing Marking"**
+- [ ] Date-format selector: "Select one or more date formats" → **"Select Date format"** (single-select)
+- [ ] Document date-format codes: **MD** (month/day), **MDD** (month and day), **YMD** (year and month), **YMDD** (year, month and day) — ⚠️ *source listed "YMDD" twice; confirm the year-and-month code with Ian*
+- [ ] Add ERD/LRD fields
+- [ ] Apply guidelines block (Issue 12)
+
+### Issue 15 — Submit New Cover page updates
+**Status:** open · **Depends on:** 12 · **Board:** F3 / F5
+- [ ] Apply guidelines block (Issue 12), including the date-verification-image note
+
+### Issue 16 — Rename "Record Details" → "Cover Details"
+**Status:** open · **Depends on:** none · **Board:** F2
+- [ ] Screen header + all nav/labels read **"Cover Details"**
+
+### Issue 17 — Submitter acknowledgement on covers
+**Status:** open · **Depends on:** 16 · **Board:** F3 / F5 · related **[R8]**
+On **Submit New Cover** (covers only, **not** markings): "Would you like your
+name to display as the submitter?" If yes → show "Submitted by [name]" on the
+Cover Details screen. Incentivizes uploads.
+- [ ] Yes/no acknowledgement checkbox on Submit New Cover
+- [ ] When yes: "Submitted by [name]" appears on Cover Details
+- [ ] When no: no submitter name shown
+- [ ] Option does **not** appear on marking submission
+
+### Issue 18 — Catalog Search: search by size (diameter)
+**Status:** open · **Depends on:** none · **Board:** F2 Collection Discovery
+- [ ] Catalog Search exposes a size/diameter filter
+- [ ] Searching by diameter returns matching markings
+
+## Markings model & display (Greg Stone parsing feedback)
+
+### Issue 19 — Ratemark display: plain vs. in-circle rate
+**Status:** open · **Depends on:** none · **Board:** F11 · **Source:** Greg Stone
+Show the difference between a plain rate ("5") and a rate enclosed in a circle —
+as the Stampless catalog distinguishes Cumberland vs. Curdsville.
+- [ ] A "5" and a circled "5" render distinguishably
+- [ ] Cumberland and Curdsville display their correct rate styling
+
+### Issue 20 — "Years Seen" model for marking dates
+**Status:** open · **Depends on:** none · **Board:** F11 · **Source:** Greg Stone
+**⚠️ Model change — scope first; record decision in `docs/DECISIONS.md`.**
+Replace the strict Earliest/Latest pair with discrete known years/ranges to handle
+hiatuses (Greg's Aquila: **1811, 1849–1855**), for both handstamp and manuscript.
+Ian's counter-view: keep Earliest+Latest and note ranges in the detail notes — to
+be resolved with the board. **Interacts with the `parse_head` year-peel (Issue 32),
+which currently *drops* trailing years this model would want to preserve.**
+- [ ] Design note: data model + migration from Earliest/Latest
+- [ ] Aquila shows "1811, 1849–1855" rather than a single 1811–1855 range
+- [ ] Handstamp listings extract years as shown in source
+- [ ] **Decision recorded in DECISIONS.md**
+
+### Issue 21 — Rate vs. Auxiliary classification decision
+**Status:** open · **Depends on:** 12 · **Board:** F11 · **Source:** Greg Stone
+**⚠️ Board decision; record in `docs/DECISIONS.md`.**
+Keep Ratemarks as a distinct class, or treat all non-townmarks as Auxiliary
+(Greg's proposal: "Paid" and "Paid 5" both Auxiliary)? Ian: *"a marking is a
+marking at the end of the day"* — wants a board ruling before conventions harden.
+- [ ] Classification decision documented with rationale
+- [ ] Guidelines (Issue 12) reflect the final convention
+- [ ] **Decision recorded in DECISIONS.md**
+
+## Content, branding & citations
+
+### Issue 22 — Rewrite the Acknowledgements page
+**Status:** open · **Depends on:** none · **Board:** F9
+Replace with Ian's supplied copy (sections: U.S. Philatelic Classics Society,
+Project Team, Beta Testers, Past Editors of the Catalogue, Donors). Full verbatim
+text in `06-09-emails.md` → "Acknowledgements" thread, and drafted at
+`worldcovers/docs/acknowledgements.md`.
+- [ ] Page matches the supplied sections
+- [ ] All named people/orgs match the email exactly (spelling verified)
+
+### Issue 23 — Branding: APMC + Classics Society
+**Status:** open · **Depends on:** none · **Board:** F2 · related **[R7]**
+**⚠️ Board approval required before merge.**
+Replace "Worldcovers" branding with **APMC**, add the U.S. Philatelic Classics
+Society logo, and add Society website / "Become a member" links.
+- [ ] "APMC" branding + Classics Society logo replace "Worldcovers"
+- [ ] Society website + membership links present and correct
+- [ ] Final branding/logo/links confirmed with the board before merge
+
+### Issue 24 — Per-state reference citations
+**Status:** open · **Depends on:** 13 · **Board:** F6 Reference Work Management
+As each state is added, attach its source reference/citation (e.g. VAPHS Catalog) —
+listings from another catalog are accepted as genuine on that catalog's authority.
+- [ ] Imported listings carry their source reference work
+- [ ] VA imports cite the VAPHS Catalog where applicable
+
+## Lower priority / later
+
+### Issue 25 — Marking with multiple states/territories
+**Status:** open · **Depends on:** none · **Board:** F11 · related **[R5]**
+Support and display a single marking belonging to more than one state/territory.
+**Spike already answered by the Michigan run:** the `post_office_regions` junction
+is **already many-to-many** (`unique_together [post_office, region]`); Detroit
+links to four regions and `PostOffice.region` resolves the display region. So this
+is largely **display + filter UI**, not a schema change. See Issue 31.
+- [ ] A marking can be associated with multiple states/territories
+- [ ] Detail screen displays all associated states
+
+### Issue 26 — Submit a cover for additional markings
+**Status:** open · **Depends on:** none · **Board:** F3 / F5
+After a cover is submitted for one marking, allow associating it with another
+marking without re-uploading (many covers carry multiple markings).
+- [ ] From a submitted cover, user can associate it with another marking without re-uploading
+
+### Issue 27 — Submitter self-delete option (open question)
+**Status:** open · **Depends on:** none · **Board:** F3
+**⚠️ Decision required.** Should submitters be able to delete their own submissions?
+- [ ] Decision recorded (yes/no) with rationale
+- [ ] If yes: submitter can delete own submission. If no: close in tracker.
+
+---
+
+# Michigan E2E open tails (from PR #50)
+
+These are concrete follow-ups surfaced by the Michigan import. They were
+**cataloged, not fixed** (Reese/Michael agreement: log each, keep separate from the
+VA patches, get a handling call before changing code). Full evidence:
+`docs/mi-edge-cases.md`, `docs/michigan-report-for-michael.md`, `docs/DECISIONS.md`.
+
+### Issue 28 — Territory-suffix residue fragments post offices  ★ biggest MI data-quality item
+**Status:** open (needs Michael's call) · **Depends on:** 7
+Head parsing leaves `M.T` / `Mic.T` / `Mich.Ty or M.T` in town names, so **173 of
+837 PO names** carry residue and the same town splits across periods (`ADRIAN M.T`
+≠ `ADRIAN`; Green Bay = 3 variants; only 37 merged cleanly). With section-driven
+regions, the suffix is now **redundant** — stripping it in `parse_head` (same family
+as the VA trailing-year peel, `8be62ca`) fixes fragmentation and loses nothing.
+User-visible today ("Town: GREEN BAY M.T"). **Not touched pending decision.**
+
+### Issue 29 — `#N` office numbers: Port Lawrence #1 / #2 (2 real markings excluded)
+**Status:** open (needs Michael's call) · **Depends on:** 7
+`#` is outside the munger's PO-name charset → import aborts. Two real Toledo-Strip
+offices (values 1000.00 / 1250.00) were provisionally re-typed LISTING→META in the
+scratch CSV to complete the run. **They must come back** once Michael picks a
+handling: allow `#` in the charset, or normalize to `NO. 1`.
+
+### Issue 30 — Bless `regions.csv` territory rows into canonical data + DB
+**Status:** open (needs Michael's go) · **Depends on:** 7
+Two proposed rows live only in the gitignored scratch `tools/wip/in/regions.csv`:
+
+| id | name | tier | parent | established | defunct |
+|---|---|---|---|---|---|
+| 59 | Michigan Territory | TERRITORY | 1 (USA) | 1805-06-30 | 1837-01-26 |
+| 60 | Indiana Territory | TERRITORY | 1 (USA) | 1800-07-04 | 1816-12-11 |
+
+Dates cross-checked (Wikipedia / Indiana Historical Bureau); follow the seed
+convention that a territory's `defunct_date` = its successor's `established_date`.
+Canonical `ASCC Data/regions.csv` and the DB are untouched pending Michael's OK.
+**Sub-question:** abbrevs for both territories — left empty (catalog only offers
+the ambiguous `M.T.`). Hard constraint for any future code: must **not** collide
+with a 2-char state abbrev (`MI`/`IN`/`MT` taken), since the munger keys catalog
+files to regions by exact filename-prefix match.
+
+### Issue 31 — Territory search/UI surfacing
+**Status:** open (design) · **Depends on:** 7 · related **25, [R5]**, M2
+Territory regions hang off USA (parent id 1), not off their successor state — so a
+`region=MI` search won't include Michigan Territory markings as modeled. Decide
+whether territories should also parent under (or alias to) their successor state
+for search. Also: region filtering is per **post office**, not per **marking** — a
+town in two regions shows all its markings under either filter (correct per the
+junction, but a territory-UI design input). Feeds the M2 territory-filter work.
+
+### Issue 32 — `parse_head` town-heading date patch (VA + MI)
+**Status:** proposed (commit `8be62ca` on PR #50) · **Depends on:** none · related **20**
+Strips bare trailing dates off town-table headings; required for both VA and MI to
+avoid digit-bearing PO-name aborts. Still a **proposal** for Michael. It currently
+**drops** the peeled year — which conflicts with Issue 20 ("Years Seen") wanting
+years preserved. Long-term fix may capture the year into a date field instead.
+
+### Issue 33 — Local backend test-DB privilege
+**Status:** open (infra) · **Depends on:** none
+`wocod` has grants only on `worldcovers.*`, so Django can't create
+`test_worldcovers` and the backend test suite doesn't run locally. A `GRANT` on
+`test_worldcovers.*` (or a documented convention) closes it. *(The four
+"migration drift" alarms from the VA write-up are **withdrawn** — fresh installs
+are healthy; see DECISIONS.md.)*
+
+### Issue 34 — VA + MI coexistence in one DB (ID offsetting)
+**Status:** open (tracked elsewhere) · **Depends on:** 5, 7
+The importer keys on raw PKs and the munger renumbers each state from 1, so MI went
+into a **fresh** DB for the E2E proof. Multi-state coexistence needs the
+ID-offsetting work (tracked as Ian's Issue #8 in the v2 backlog). Noted here only
+to confirm MI E2E does **not** attempt it.
+
+---
+
+# Open decisions awaiting Ian / Michael / the board
+
+| # | Decision | Owner | Blocks |
+|---|---|---|---|
+| 14 | Confirm the "year-and-month" date-format code (source listed YMDD twice) | Ian | 14 |
+| 20 | "Years Seen" vs. Earliest/Latest date model | Board + Greg | 20, 32 |
+| 21 | Rate vs. Auxiliary classification | Board | 12, 21 |
+| 23 | APMC branding / logo / Society links sign-off | Board | 23 |
+| 27 | Allow submitter self-delete? | Ian | 27 |
+| 28 | Strip territory suffixes in `parse_head`? | Michael | 28 |
+| 29 | `#N` office-name handling (allow `#` or `NO. N`) | Michael | 29 |
+| 30 | Bless territory region rows into canonical `regions.csv` + DB; territory abbrevs | Michael | 30 |
+| 31 | Territory search behavior (parent under successor state?) | Michael | 25, 31 |
+
+---
+
+# Out of scope / non-engineering follow-ups
+
+- **Hosting cost** — Bob / Eric Stone meeting on APMC hosting (Website ~$975/qtr, Chronicle ~$465/qtr); Eric asked for a load/cost recommendation. Business decision.
+- **Billing/naming** — confirm "Covercensus" == "Worldcovers" for tax/billing (pending Michael).
+- **ASCC data-model doc** — reference only (Google Doc linked in `06-09-emails.md` → "ASCC database" thread).
+- **IanThom.org / ChinaOverprints / account admin / Jay Logan transition** — separate, lower-precedence track. Not tracked here.
+
+---
+
+# Appendix — Live Trello board reconciliation (`HDC2qwhi`)
+
+The live board is a feature-based story map, distinct from the email issues above.
+It is the authority for `F#/S#/T#` numbering; **don't reuse those prefixes for the
+email issues** (see the numbering note at the top).
+
+**Features:** F1 Authentication · F2 Collection Discovery · F3 Submission Workflow ·
+F4 Comment Workflow · F5 Image Attachments · F6 Reference Work Management ·
+F7 Collection Administration · F8 Audit Trail · F9 Documentation & Help ·
+F10 System Maintenance · F11 Catalog Data Pipeline.
+
+**Board state (open cards):**
+- **Doing:** `S5` Export records in supported formats (F2); `S31` Load transformed data into a running system (F11).
+- **To Do:** `T4` Basic unit tests (Jest/PyUnit); `T6` Performance testing / load balancing.
+- **Testing:** `S30` Transform catalog data from source formats, `S32` Bundle transformed data for export (F11 — **the pipeline Reese exercised for VA/MI**); plus `S6–S8, S12, S15–S20, S22–S24, S27` across F3–F10.
+- **Done:** `S0–S4, S9–S11, S13–S14, S21, S25–S26, S28–S29, S3` (auth, browse/search, submission review, backup/restore, catalog query/stats).
+- **Backlog:** `S33–S49` (tooltips, docs articles, bulk approve, notifications, tags, ratings, infinite scroll/pagination, image search, SSO/MFA, etc.) and `T1–T3, T5` (dev docs, a11y/i18n, security hardening, UI tests).
+
+**Where the email issues touch the board** (build against the corresponding feature):
+Issues 1–7, 19–20, 24 → **F11 / F6**; Issues 9–17, 26 → **F3 / F5**; Issue 18, 16, 23 → **F2**;
+Issues 10 → **F1**; Issues 12, 22 → **F9**.
+
+The email issues are mostly **new beta feedback not yet on the board** — they should
+be added as cards under the matching feature when triaged, using the board's real
+`S#/T#` sequence (next free numbers), not the ad-hoc scheme.

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -199,10 +199,14 @@ rolls everything back (no partial state).
    ```bash
    uv run python backend/manage.py shell -c "from django.contrib.auth import get_user_model as G; U=G(); U.objects.filter(id=1).exists() or U(id=1,username='admin',is_superuser=True,is_staff=True).save()"
    ```
-2. **Schema fixes for `staging` migration drift** — see DECISIONS.md "staging
-   fresh-install schema is incomplete." On a fresh `staging` DB these four are
-   needed before the import succeeds (local DB only; the real fix is Michael's
-   migrations):
+2. **Schema fixes — check for symptoms first, usually NOT needed.** A truly
+   fresh DB + `migrate` on a staging-based branch produces a complete schema
+   (verified on the MI run, 2026-06-11: import succeeded with zero fixes).
+   The four drifts below were observed once (VA run, 2026-06-09) and were
+   almost certainly residue of an earlier broken-`main` migrate attempt
+   against the same DB. Apply a fix only if its specific import error
+   appears (1364 region_id / 1146 post_office_region / 1054 is_tracing /
+   1062 duplicate storage_filename):
    ```sql
    ALTER TABLE post_office MODIFY region_id BIGINT NULL;   -- orphaned NOT NULL col
    ALTER TABLE images DROP INDEX storage_filename;          -- model says NOT unique

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -165,6 +165,22 @@ post_offices (1057), post_office_regions (1057), markings (2813), dates_seen
 > Without it the munger aborts with "PostOffice normalization produced N
 > name(s) with characters outside [A-Z, space, period, single dash]."
 
+**Verify the "Section-region assignment" report** printed at the top of the
+munge output. Listings are assigned the region of the catalog section they
+sit under (META banners matching a TERRITORY-tier name in `regions.csv`,
+optionally prefixed `AS `; a `STATEHOOD` banner resets to the catalog's
+default region). Check that:
+
+- the per-region listing counts match the catalog's section sizes
+  (single-region catalogs like VA show one line: all listings on the default);
+- nothing under "Unmatched banner-like META rows" is a real territory
+  section the vision step misread (e.g. `MICHIGAN TERRlTORY`) — if it is,
+  fix the row in the extract CSV and re-munge.
+
+A post office listed under several sections (e.g. Detroit) gets one
+`post_office_regions` row per section region, so junction-row count can
+exceed post-office count on territory-bearing catalogs.
+
 ## G. Import  (deterministic, no API)
 
 ```bash

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,0 +1,251 @@
+# ASCC Catalog Pipeline — Runbook
+
+Turn a state sub-catalog PDF into rows in the WorldCovers database. This is the
+canonical, reproducible path; it supersedes the notebook chain described in
+`docs/devel/TOOLS.md` (those notebooks no longer exist — the pipeline is now the
+`tools/ascc_*.py` scripts below).
+
+**Validated end-to-end against Virginia (`VA_ASCC_CTLG`), 2026-06-09.**
+
+---
+
+## 0. Prerequisites
+
+| Need | How |
+|------|-----|
+| Python env | `uv sync` in repo root (set `CC=gcc CXX=g++` if `mysqlclient` fails to build) |
+| MySQL DB | `worldcovers` DB migrated; see `tools/rebuild_staging_db.sh`. Work on `staging` branch (see `DECISIONS.md` re: `main` migration bug) |
+| `pdftoppm` | poppler-utils. `sudo apt-get install -y poppler-utils`, or no-sudo `brew install poppler` |
+| `OPENROUTER_API_KEY` | in **`worldcovers/.env`** (the scripts load `TOOLS_DIR.parent/.env`, i.e. the repo-root `.env`, NOT the workspace-root one). Account must have credit — the vision stages call the paid model `anthropic/claude-sonnet-4.6` |
+
+### The `BASE` convention
+
+Every script keys off one basename, e.g. `VA_ASCC_CTLG`. It must:
+- be the input PDF's filename stem: `tools/wip/in/<BASE>.pdf`
+- start with the 2-letter region abbrev (`VA`) — the munger derives `REGION_ABBREV`
+  from `os.path.basename(input)[:2]`, and the processor/extract derive the state
+  header (`VA` → `VIRGINIA`) from the first `_`-delimited token via `regions.csv`.
+
+> All of `tools/wip/{in,out,cache}/` is gitignored (incl. all pdf/png/jpg) — safe scratch.
+
+### Seed files (place in `tools/wip/in/` before starting)
+
+- `<BASE>.pdf` — the state sub-catalog
+- `reference_works.csv` — **exactly 1 data row** (the catalog being cited); munger raises otherwise
+- `regions.csv` — must contain exactly 1 row matching `REGION_ABBREV`
+
+---
+
+## Stage map
+
+| # | Script | API? | Reads | Writes |
+|---|--------|------|-------|--------|
+| A | `ascc_page_processor.py … --stages render` | no | `wip/in/<BASE>.pdf` | `wip/cache/<BASE>_full/page-*.png` |
+| B | `ascc_page_processor.py … --stages halves` | ✅ | full pages | `wip/cache/<BASE>_halves/` |
+| C | `ascc_page_processor.py … --stages chunks` | ✅ | halves | `wip/out/<BASE>/page-NNNN-MMMM.png` |
+| — | **hop 1** | — | move chunks `wip/out/<BASE>/` → `wip/in/<BASE>/` | extract/image_extract read from `in/` |
+| D | `ascc_page_extract.py <BASE>` | ✅ | `wip/in/<BASE>/` chunks | `wip/out/<BASE>.csv` |
+| E | `ascc_image_extract.py <BASE>` | no | `wip/in/<BASE>/` chunks + `wip/out/<BASE>.csv` | `wip/out/<BASE>_images/` |
+| F | `ascc_data_munger.py --input … --input-dir …` | no | extract CSV + seeds + images | Django-shape CSVs in `wip/out/` |
+| G | `manage.py import_ascc_bundle <out-dir>` | no | the bundle | rows in MySQL |
+
+All commands run from the repo root (`worldcovers/`).
+
+---
+
+## A. Render  (deterministic)
+
+```bash
+uv run python tools/ascc_page_processor.py VA_ASCC_CTLG --stages render
+```
+
+Result (VA): **17 pages** rendered at 300 DPI → `wip/cache/VA_ASCC_CTLG_full/`.
+
+## B. Halves  (vision)
+
+```bash
+uv run python tools/ascc_page_processor.py VA_ASCC_CTLG --stages halves
+```
+
+Per page: deterministic vertical-rule detection, with a vision page-number read
+and a single-column-confirm fallback. Crops to L/R halves named by **catalog**
+page number.
+
+Result (VA): catalog pages **419–435**, **34 half-images**, 20 vision calls
+(4 `vision_confirmed_weak_rule`). **Inspect a sampling of halves for seam-clipped
+text/markings before proceeding** (the script reminds you).
+
+## C. Chunks  (vision)
+
+```bash
+uv run python tools/ascc_page_processor.py VA_ASCC_CTLG --stages chunks
+```
+
+Per half: deterministic dark/blank row-block detection + vision per-block
+classify (illustration vs text); cut at the top of every illustration block.
+
+Result (VA): 795 blocks detected, 173 illustrations, **201 chunk PNGs** →
+`wip/out/VA_ASCC_CTLG/page-NNNN-MMMM.png` (~34 min; 795 classify + 197 review
+vision calls).
+
+## hop 1 — move chunks where the downstream scripts read them
+
+The processor writes chunks to `wip/out/<BASE>/`, but `ascc_page_extract.py` and
+`ascc_image_extract.py` both read from `wip/in/<BASE>/`. Move them:
+
+```bash
+mkdir -p tools/wip/in/VA_ASCC_CTLG
+mv tools/wip/out/VA_ASCC_CTLG/* tools/wip/in/VA_ASCC_CTLG/
+```
+
+## D. Extract  (vision)
+
+```bash
+uv run python tools/ascc_page_extract.py VA_ASCC_CTLG
+```
+
+Sends each chunk to the vision model; writes catalog rows (Listing, Page,
+Chunk, Images Above, Type) to `wip/out/VA_ASCC_CTLG.csv`.
+
+Result (VA): **1,596 rows** (1,539 LISTING + 57 META), 167 chunks with
+`Images Above >= 1` (~22 min).
+
+> **Per-chunk review (the "reviewed CSV"):** the vision pass can over-count
+> markings on a noisy chunk. VA page 419 chunk 14 was tagged `Images Above=2`
+> but contains only one marking (a cursive "Nfk" manuscript mark; the ornate
+> "NORFOLK" below is a section banner, not a marking). image-extract (next
+> step) refuses to fabricate the 2nd image and flags `marking_count_mismatch`,
+> and the munger then aborts on the missing file. Fix: correct that row's
+> `Images Above` to the true count in the CSV and re-run image-extract for the
+> page. This is the human review the pipeline assumes between extract and munge.
+
+## E. Image extract  (deterministic, no API)
+
+```bash
+uv run python tools/ascc_image_extract.py VA_ASCC_CTLG
+```
+
+For each chunk with `Images Above >= 1`, cuts the marking illustration(s) out by
+gap/dark-region geometry (no vision). Writes
+`wip/out/VA_ASCC_CTLG_images/va-<page>-<chunk>-<counter>.png`. Use `--pages 419`
+to re-run a single page after a review correction.
+
+Result (VA): 167 subchunks, **205 marking images** (after the chunk-14 review
+fix; 204 before), all `ok`.
+
+### hop 2 — copy marking images into Django's media root
+
+The munger (next step) reads marking bytes from `MEDIA_ROOT/<region>/`, not from
+`wip/out/`. Copy them:
+
+```bash
+mkdir -p backend/media/va
+cp tools/wip/out/VA_ASCC_CTLG_images/*.png backend/media/va/
+```
+
+## F. Munge  (deterministic, no API)
+
+Point `--input` at the extract CSV in `out/`, `--input-dir` at the seeds in `in/`
+(avoids copying the CSV back into `in/`):
+
+```bash
+uv run python tools/ascc_data_munger.py \
+  --input tools/wip/out/VA_ASCC_CTLG.csv \
+  --input-dir tools/wip/in
+```
+
+Writes the full Django-shape CSV set to `wip/out/`: colors (16), letterings (9),
+shapes (16), regions (58, passthrough), reference_works (1, passthrough),
+post_offices (1057), post_office_regions (1057), markings (2813), dates_seen
+(3443), citations (2813), images (276), plus `marking_lineage.csv` sidecar.
+
+> **Town-heading date parsing:** see DECISIONS.md — a local patch to
+> `tools/munger/head.py` (`parse_head`) is required to strip bare trailing
+> years off town-table headings (`Accomack C.H 1835` → `Accomack C.H`).
+> Without it the munger aborts with "PostOffice normalization produced N
+> name(s) with characters outside [A-Z, space, period, single dash]."
+
+## G. Import  (deterministic, no API)
+
+```bash
+uv run python backend/manage.py import_ascc_bundle ./tools/wip/out/
+```
+
+Loads in FK-safe order (colors → letterings → shapes → regions →
+reference_works → post_offices → post_office_regions → markings → … →
+citations → images). `covers / cover_valuations / cover_markings` are absent for
+this catalog and are skipped. The whole bundle is one transaction — any error
+rolls everything back (no partial state).
+
+**Pre-reqs the bundle needs in the DB (one-time):**
+
+1. **A user with `id=1`.** Every row's `created_by/modified_by` references user 1.
+   ```bash
+   uv run python backend/manage.py shell -c "from django.contrib.auth import get_user_model as G; U=G(); U.objects.filter(id=1).exists() or U(id=1,username='admin',is_superuser=True,is_staff=True).save()"
+   ```
+2. **Schema fixes for `staging` migration drift** — see DECISIONS.md "staging
+   fresh-install schema is incomplete." On a fresh `staging` DB these four are
+   needed before the import succeeds (local DB only; the real fix is Michael's
+   migrations):
+   ```sql
+   ALTER TABLE post_office MODIFY region_id BIGINT NULL;   -- orphaned NOT NULL col
+   ALTER TABLE images DROP INDEX storage_filename;          -- model says NOT unique
+   ```
+   ```python
+   # create 4 model-declared tables 0001_initial never built, + images.is_tracing:
+   from django.db import connection; from django.apps import apps
+   from common.models import Image
+   with connection.schema_editor() as se:
+       for n in ['PostOfficeRegion','CoverVersion','MarkingRecycleBin','CoverRecycleBin']:
+           se.create_model(apps.get_model('common', n))
+       se.add_field(Image, Image._meta.get_field('is_tracing'))
+   ```
+
+Result (VA): **`Done. new=11559  update=0  skip=0  invalid=0  error=0`**
+(post_offices 1057, post_office_regions 1057, markings 2813, dates_seen 3443,
+citations 2813, images 276, + 58 auto-created Collections).
+
+---
+
+## Verify
+
+1. `./woco dev`, open `http://localhost:8080`.
+2. Search for a Virginia marking; confirm the listing AND its marking image render.
+
+Verified for VA at the API/media layer (what the search page consumes):
+
+```bash
+curl -s http://localhost:8000/api/v2/markings/1/ | python3 -m json.tool   # state VA, region Virginia, 1 image w/ image_url
+curl -s -o /dev/null -w '%{http_code} %{content_type}\n' \
+  http://localhost:8000/media/va/va-419-2-1.png                            # 200 image/png
+```
+
+`/api/v2/markings/?page=1` returns `count: 2813`; post-office names are clean
+(0 digit-bearing names; `ACCOMACK`, `ACCOMACK C.H` present).
+
+---
+
+## Gotchas found while validating VA
+
+- **`.env` location:** scripts read `worldcovers/.env`, not the workspace-root `.env`.
+- **Free-tier OpenRouter** keys (no credit) 402 on the paid vision model. Use a funded key.
+- **`pdftoppm`** must be on PATH (poppler). No-sudo option: `brew install poppler`.
+- **Three file-hops:** chunks `out/<BASE>/` → `in/<BASE>/` (hop 1); marking images
+  `out/<BASE>_images/` → `backend/media/<region>/` (hop 2); the munger can read the
+  extract CSV from `out/` directly via `--input` + `--input-dir`.
+- **`reference_works.csv` ships with 2 rows** (ASCC1 + ASCC2); the munger requires
+  exactly 1. For the VA baseline we keep ASCC1 (the published 5th edition the scan
+  is from). See DECISIONS.md.
+- **`main` branch** can't migrate a fresh DB (`InvalidBasesError`); use `staging`.
+- **`staging` migrates but the schema is incomplete** (4 drifts) — see the Stage G
+  pre-reqs and DECISIONS.md. This is the single biggest blocker to a clean repro and
+  is Michael's to fix at the migration level.
+
+## Summary of changes this runbook depends on
+
+| Change | Where | Status |
+|--------|-------|--------|
+| `parse_head` town-heading date peel | `tools/munger/head.py` (code) | local patch, branch `reese/issue-1-va-e2e`, **proposed to Michael** |
+| 4 schema fixes + user id=1 | local MySQL only | local workaround; **Michael fixes migrations** |
+| chunk-14 `Images Above` correction | scratch CSV | per-chunk review (expected workflow) |
+| keep ASCC1 in `reference_works.csv` | scratch seed | baseline choice |

--- a/tools/ascc_data_munger.py
+++ b/tools/ascc_data_munger.py
@@ -28,7 +28,12 @@ from munger.fields.rates import RATE_BRACKET_RE, parse_rate_token, split_rate_to
 from munger.fields.sizes import parse_size_field
 from munger.head import parse_head, parse_manuscript_row
 from munger.images import MEDIA_ROOT
-from munger.io import OPTIONAL_COLS, REQUIRED_COLS, process_meta_rows
+from munger.io import (
+    OPTIONAL_COLS,
+    REQUIRED_COLS,
+    assign_section_regions,
+    process_meta_rows,
+)
 from munger.rate_assembly import BRACKET_DIM_RE, BRACKET_SHAPE_MAP, _date_cls, _tm_codes_by_listing, parse_rate_amount
 from munger.relationships import OR_ALIAS_RE, TOWN_HEADING_RE, _is_abbrev_of, _norm_for_alias, resolve_relationships, roll_up_catalog_text
 from munger.segment import classify_entry_form, decompose_tail, segment_entry, split_paren_fields, split_valuation_tiers
@@ -78,6 +83,7 @@ def main(argv=None):
         raise ValueError(
             f'Required columns missing from {INPUT_CSV}: {missing_required}'
         )
+    df['section_region_id'] = assign_section_regions(df, _region_seed, REGION_ID)
     meta_df = df[df['Type'] == 'META'].reset_index(drop=True)
     listings_df = df[df['Type'] == 'LISTING'].reset_index(drop=True)
     process_meta_rows(meta_df)
@@ -1824,15 +1830,43 @@ def main(argv=None):
             lambda sc: unknown_by_state[_nkey(sc)]
         ).values
         print(f'  Assigned {unresolved.sum()} townmarks to UNKNOWN post office(s) across {len(unknown_by_state)} state(s)')
+    # One junction row per distinct (post office, section region) pair: a
+    # post office listed under several catalog sections (e.g. Detroit under
+    # Northwest Territory, Indiana Territory, Michigan Territory, and
+    # statehood) links to each of those regions. POs with no listing-derived
+    # pair (the UNKNOWN fallbacks) get the catalog default region.
+    _po_region_pairs = (
+        listings[['post_office_id', 'section_region_id']]
+        .dropna()
+        .astype(int)
+        .drop_duplicates()
+        .rename(columns={'section_region_id': 'region_id'})
+    )
+    _covered_pos = set(_po_region_pairs['post_office_id'])
+    _uncovered = [
+        {'post_office_id': int(pid), 'region_id': REGION_ID}
+        for pid in post_offices_df['post_office_id']
+        if int(pid) not in _covered_pos
+    ]
+    if _uncovered:
+        _po_region_pairs = pd.concat(
+            [_po_region_pairs, pd.DataFrame(_uncovered)], ignore_index=True
+        )
+    _po_region_pairs = (
+        _po_region_pairs
+        .sort_values(['post_office_id', 'region_id'])
+        .reset_index(drop=True)
+    )
     post_office_regions_df = pd.DataFrame({
-        'post_office_region_id': range(1, len(post_offices_df) + 1),
-        'post_office_id': post_offices_df['post_office_id'].astype(int).values,
-        'region_id': REGION_ID,
+        'post_office_region_id': range(1, len(_po_region_pairs) + 1),
+        'post_office_id': _po_region_pairs['post_office_id'].astype(int).values,
+        'region_id': _po_region_pairs['region_id'].astype(int).values,
     })
     print(f'PostOffice records: {len(post_offices_df)}')
     print(f'  From {listings["resolved_town"].nunique()} raw distinct towns')
     print(f'  To {len(post_offices_df)} normalized post offices')
-    print(f'PostOfficeRegion links: {len(post_office_regions_df)} (all -> region_id={REGION_ID})')
+    print(f'PostOfficeRegion links: {len(post_office_regions_df)} '
+          f'across {post_office_regions_df["region_id"].nunique()} region(s)')
     if post_offices_df['state_code'].notna().any():
         per_state = post_offices_df.groupby('state_code').size()
         print(f'  Per state:')

--- a/tools/munger/head.py
+++ b/tools/munger/head.py
@@ -105,6 +105,47 @@ def parse_head(row):
 
     # 5. Name body: head text with annotation parens removed, stripped
     name_body = PAREN_GROUP_RE.sub('', head).strip()
+
+    # 5b. Peel a bare trailing date field off town-table headings.
+    #     Town-listing rows print as "NAME .... YEAR(S) .... VALUE" with
+    #     dot-leader separators (ascc_page_extract compresses the leaders
+    #     to "..."). strip_dot_leaders flattens those to spaces before
+    #     segmentation, so once segment_entry removes the trailing value
+    #     the head arrives here as e.g. "Accomack C.H 1835",
+    #     "Aquia 1811,1849-55", or "Arbor Hill 1850's" -- the year is
+    #     glued to the town name. parse_manuscript_row already peels this
+    #     for Manuscript-flagged rows; reuse its exact loop (date, then
+    #     dash placeholder, then trailing separators) so the normal
+    #     (non-manuscript) path normalizes identically. The dash/sep peels
+    #     also clear a "--/" residue left on the head when a slash-tiered
+    #     value like "--/15.00" is only partly consumed by segment_entry,
+    #     which otherwise hides the date from MS_DATE_AT_END's end-anchor.
+    #     No-op for rows whose dates were parenthesized annotations (those
+    #     were removed in step 5), so manuscript-section parsing is
+    #     unchanged.
+    if name_body:
+        while True:
+            m_date = MS_DATE_AT_END.search(name_body)
+            if m_date:
+                name_body = name_body[:m_date.start()].rstrip()
+                continue
+            m_dash = MS_DASH_AT_END.search(name_body)
+            if m_dash:
+                name_body = name_body[:m_dash.start()].rstrip()
+                continue
+            m_sep = MS_SEP_AT_END.search(name_body)
+            if m_sep:
+                name_body = name_body[:m_sep.start()].rstrip()
+                continue
+            break
+
+    # 5c. Drop residues with no real town text (e.g. a row that was just a
+    #     bare year like "1849"): they would otherwise become a PostOffice
+    #     name made only of digits and fail downstream normalization. A
+    #     None town routes the row to the UNKNOWN post office instead.
+    if name_body and not re.search(r'[A-Za-z]{2,}', name_body):
+        name_body = None
+
     name_body = name_body if name_body else None
 
     return pd.Series({

--- a/tools/munger/io.py
+++ b/tools/munger/io.py
@@ -57,11 +57,15 @@ def assign_section_regions(df, region_seed, default_region_id: int) -> pd.Series
             if key in territory_by_name:
                 current = territory_by_name[key]
                 switches.append((banner, current))
-            elif 'STATEHOOD' in banner:
-                current = int(default_region_id)
-                switches.append((banner, current))
             elif _BANNER_CANDIDATE.fullmatch(banner):
-                unmatched[banner] = unmatched.get(banner, 0) + 1
+                # STATEHOOD only resets on banner-shaped rows: narrative
+                # META paragraphs mention statehood freely (the MI intro
+                # does, right inside the territory section).
+                if 'STATEHOOD' in banner:
+                    current = int(default_region_id)
+                    switches.append((banner, current))
+                else:
+                    unmatched[banner] = unmatched.get(banner, 0) + 1
         assigned.append(current)
 
     out = pd.Series(assigned, index=df.index, dtype='int64')

--- a/tools/munger/io.py
+++ b/tools/munger/io.py
@@ -1,3 +1,5 @@
+import re
+
 import pandas as pd
 
 
@@ -5,8 +7,85 @@ REQUIRED_COLS = ['Listing', 'Page', 'Chunk', 'Images Above', 'Type']
 
 OPTIONAL_COLS = ['Manuscript', 'Default Shape', 'Institutional Ownership']
 
+_WS = re.compile(r'\s+')
+
+# Unmatched-banner report: all-caps META lines that look like section
+# headings (so a misread banner shows up in the verify step instead of
+# silently leaving its listings on the catalog default region).
+_BANNER_CANDIDATE = re.compile(r"[A-Z][A-Z .,'&-]{3,40}")
+
+
+def _norm_banner(text) -> str:
+    return _WS.sub(' ', str(text)).strip().upper()
+
+
+def assign_section_regions(df, region_seed, default_region_id: int) -> pd.Series:
+    """Per-listing region id derived from the catalog section each row
+    sits under, walking rows in CSV (reading) order and tracking the
+    active section across META banner rows.
+
+    Only TERRITORY-tier region names switch the active section -- the
+    catalog's section banners ("MICHIGAN TERRITORY", optionally prefixed
+    "AS NORTHWEST TERRITORY") name the territory in force, while town
+    strings only carry abbreviations like "M.T." that the ASCC header
+    explicitly calls ambiguous (Michigan / Minnesota / Mississippi
+    Territory). A banner containing STATEHOOD resets to
+    default_region_id. Bare state names never match: the page running
+    head (e.g. "MICHIGAN") survives extraction as a META row on every
+    page and must not reset the section.
+
+    Returns an int64 Series aligned to df.index. Catalogs without
+    territory banners (e.g. VA) come back all default_region_id.
+    """
+    territory_by_name = {
+        _norm_banner(row['name']): int(row['id'])
+        for _, row in region_seed.iterrows()
+        if str(row.get('region_tier', '')).strip().upper() == 'TERRITORY'
+    }
+    region_name_by_id = {
+        int(row['id']): str(row['name']) for _, row in region_seed.iterrows()
+    }
+
+    current = int(default_region_id)
+    assigned = []
+    switches = []
+    unmatched = {}
+    for _, row in df.iterrows():
+        if row['Type'] == 'META':
+            banner = _norm_banner(row['Listing'])
+            key = banner[3:] if banner.startswith('AS ') else banner
+            if key in territory_by_name:
+                current = territory_by_name[key]
+                switches.append((banner, current))
+            elif 'STATEHOOD' in banner:
+                current = int(default_region_id)
+                switches.append((banner, current))
+            elif _BANNER_CANDIDATE.fullmatch(banner):
+                unmatched[banner] = unmatched.get(banner, 0) + 1
+        assigned.append(current)
+
+    out = pd.Series(assigned, index=df.index, dtype='int64')
+
+    listing_mask = df['Type'] == 'LISTING'
+    counts = out[listing_mask].value_counts().sort_index()
+    print('Section-region assignment:')
+    for region_id, n in counts.items():
+        name = region_name_by_id.get(int(region_id), '?')
+        print(f'  region {int(region_id)} ({name}): {int(n)} listings')
+    if switches:
+        print(f'  Section switches ({len(switches)}):')
+        for banner, region_id in switches:
+            print(f'    {banner!r} -> region {region_id}')
+    if unmatched:
+        print('  Unmatched banner-like META rows (verify none is a real section):')
+        for banner, n in sorted(unmatched.items(), key=lambda kv: -kv[1])[:15]:
+            print(f'    {banner!r} x{n}')
+    return out
+
+
 def process_meta_rows(meta_df):
-    # TODO: parse META rows for section-heading / state-heading context,
-    # column headers, and cross-reference targets. Inputs: meta_df with
-    # columns Listing, Page, Chunk, Images Above, Type. Currently a no-op.
+    # TODO: parse META rows for column headers and cross-reference
+    # targets. Inputs: meta_df with columns Listing, Page, Chunk,
+    # Images Above, Type. Section/state-heading context is handled by
+    # assign_section_regions(). Currently a no-op.
     return None

--- a/tools/test_munger_sections.py
+++ b/tools/test_munger_sections.py
@@ -44,6 +44,11 @@ class TestAssignSectionRegions(unittest.TestCase):
             ('AS INDIANA TERRITORY', 'META'),
             ('Detroit(E)(June 1, 1803;Ms;Black) 1750', 'LISTING'),
             ('MICHIGAN TERRITORY', 'META'),
+            # Narrative META mentioning statehood must NOT reset the
+            # section (the real MI intro paragraph does exactly this).
+            ('1830 Post Office Directory lists 61 Michigan Territory '
+             'Offices. The total number of Michigan offices established '
+             'prior to statehood is a surprising 340!', 'META'),
             ('Ann Arbor M.T.(E)(1825;Ms;Black)', 'LISTING'),
             ('MICHIGAN', 'META'),                       # running head mid-section
             ('Green Bay M.T.(1825;Ms;Black)', 'LISTING'),

--- a/tools/test_munger_sections.py
+++ b/tools/test_munger_sections.py
@@ -1,0 +1,86 @@
+"""Tests for section-driven region assignment (munger.io).
+
+Run from repo root:
+    .venv/bin/python -m unittest discover -s tools -p 'test_munger_sections.py'
+
+Expected exit code: 0.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+TOOLS_DIR = Path(__file__).resolve().parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+from munger.io import assign_section_regions
+
+REGION_SEED = pd.DataFrame([
+    {'id': 1,  'name': 'United States of America', 'region_tier': 'COUNTRY'},
+    {'id': 25, 'name': 'Michigan',                 'region_tier': 'STATE'},
+    {'id': 36, 'name': 'Northwest Territory',      'region_tier': 'TERRITORY'},
+    {'id': 51, 'name': 'Virginia',                 'region_tier': 'STATE'},
+    {'id': 59, 'name': 'Michigan Territory',       'region_tier': 'TERRITORY'},
+    {'id': 60, 'name': 'Indiana Territory',        'region_tier': 'TERRITORY'},
+])
+
+
+def _df(rows):
+    return pd.DataFrame(rows, columns=['Listing', 'Type'])
+
+
+class TestAssignSectionRegions(unittest.TestCase):
+
+    def test_michigan_catalog_sections(self):
+        df = _df([
+            ('MICHIGAN', 'META'),                       # state heading
+            ('BRITISH COLONIAL PERIOD', 'META'),        # no region -> default
+            ('"Detroit 30 May 1769" dateline', 'LISTING'),
+            ('AS NORTHWEST TERRITORY', 'META'),
+            ('*Detroit*(Feb. 14, 1792;SL-21x3,MDD;Black)', 'LISTING'),
+            ('AS INDIANA TERRITORY', 'META'),
+            ('Detroit(E)(June 1, 1803;Ms;Black) 1750', 'LISTING'),
+            ('MICHIGAN TERRITORY', 'META'),
+            ('Ann Arbor M.T.(E)(1825;Ms;Black)', 'LISTING'),
+            ('MICHIGAN', 'META'),                       # running head mid-section
+            ('Green Bay M.T.(1825;Ms;Black)', 'LISTING'),
+            ('STATEHOOD PERIOD', 'META'),
+            ('ADRIAN/MIC.(1838;C-30;Black)', 'LISTING'),
+            ('MANUSCRIPT TOWN MARKS', 'META'),
+            ('SCHOOLCRAFT/Mich.(1838-52;30;Black)', 'LISTING'),
+        ])
+        out = assign_section_regions(df, REGION_SEED, default_region_id=25)
+        listing_regions = out[df['Type'] == 'LISTING'].tolist()
+        self.assertEqual(listing_regions, [25, 36, 60, 59, 59, 25, 25])
+
+    def test_running_head_does_not_reset_territory_section(self):
+        # Load-bearing: the bare state name survives extraction as META on
+        # every page; matching it would silently end the territory section.
+        df = _df([
+            ('MICHIGAN TERRITORY', 'META'),
+            ('Pontiac M.T.(1830;Ms;Black)', 'LISTING'),
+            ('MICHIGAN', 'META'),
+            ('Saginaw M.T.(1835;Ms;Black)', 'LISTING'),
+        ])
+        out = assign_section_regions(df, REGION_SEED, default_region_id=25)
+        self.assertEqual(out[df['Type'] == 'LISTING'].tolist(), [59, 59])
+
+    def test_catalog_without_territory_banners_is_all_default(self):
+        # VA-shaped input: nothing matches, every listing keeps the
+        # filename-derived region (regression guard for existing catalogs).
+        df = _df([
+            ('VIRGINIA', 'META'),
+            ('Town Postmark Dates Seen Size Color Value', 'META'),
+            ('Accomack C.H(1835;Ms;Black)', 'LISTING'),
+            ('MANUSCRIPT TOWN MARKS', 'META'),
+            ('AQUIA/Va.(1849-55;30;Black)', 'LISTING'),
+        ])
+        out = assign_section_regions(df, REGION_SEED, default_region_id=51)
+        self.assertEqual(out[df['Type'] == 'LISTING'].tolist(), [51, 51])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Proposal branch from Reese — reproducing VA end-to-end and running Michigan E2E with pre-statehood (territory) support. Opening as draft for review. (Supersedes #49, which was opened from a fork before I had push access.)

## Start here — this thread is self-contained

**Status: Michigan is imported end-to-end (10,224 rows, 0 errors) and the extraction is verified to 100%** (three-layer audit; one transcription error found and fixed). What remains are catalog-policy decisions only you can make — they're in the [open-items list](https://github.com/CoverCensus/worldcovers/pull/50#issuecomment-4683474582), in priority order.

Map of the thread:

1. [**MI E2E results + the open-items list**](https://github.com/CoverCensus/worldcovers/pull/50#issuecomment-4683474582) — the import numbers, the schema-drift downgrade, and the **6 items needing your call** (territory-suffix stripping, Port Lawrence `#N`, the 1769 dateline, territory abbrevs, blessing the region rows, territory search/UI).
2. [**Edge-case inventory (full)**](https://github.com/CoverCensus/worldcovers/pull/50#issuecomment-4686237000) — all 9 MI divergences from the VA baseline, cataloged not fixed, plus the config-only architecture evidence.
3. [**Chunk-level verification report (full)**](https://github.com/CoverCensus/worldcovers/pull/50#issuecomment-4686239428) — pixel-exact chunk reconstruction, all 1,457 v1 rows cross-checked, full second-model re-extraction; the one error (`Cassamas`→`Cassapolis`) and its fix. Summary version [here](https://github.com/CoverCensus/worldcovers/pull/50#issuecomment-4685855839).
4. [**Frontend spot-check — PASS**](https://github.com/CoverCensus/worldcovers/pull/50#issuecomment-4683793784) — the real UI over the MI import; territories already appear in the State filter.
5. [Section-reset bugfix note](https://github.com/CoverCensus/worldcovers/pull/50#issuecomment-4682379551) (`adfe130`) — found by running the real MI extract through the new feature.

`ISSUE.md` in the diff carries the detailed write-up with the branch itself.

## What's in the diff

1. **`8be62ca` fix(munger):** strip bare trailing dates off town-table headings in `parse_head` (`Accomack C.H 1835` → `Accomack C.H`). Required for VA to munge at all — 752 post-office names otherwise fail the digit assertion. Reuses your existing `MS_DATE_AT_END`/`MS_DASH_AT_END`/`MS_SEP_AT_END` regexes, so manuscript-section behavior is unchanged. Caveat: it *drops* the peeled year, which intersects the "Years Seen" question — flagged in the open items.
2. **`59fe014` docs:** `docs/PIPELINE.md` — the step-by-step ASCC pipeline runbook, validated by running VA E2E locally (11,559 rows, 0 import errors).
3. **`0bf714b` feat(munger):** section-driven region assignment. Listings take the region of the catalog section banner above them (TERRITORY-tier `regions.csv` names, optional `AS ` prefix; `STATEHOOD` resets to the catalog default; bare state names ignored — the page running head survives extraction as META on every page). `post_office_regions` now emits one row per distinct (post office, region) pair, so Detroit links to each region it operated under. Implements the section-heading half of the `process_meta_rows` TODO. 3 unit tests; re-munging VA is byte-identical modulo run timestamps.
4. **`adfe130` fix:** STATEHOOD section-reset now requires banner-shaped rows (was matching narrative META that mentions "statehood"). Found live on the MI run; test added.

## Not in the diff (proposed, awaiting your OK)

Two `regions.csv` rows, currently only in gitignored scratch:

| id | name | tier | parent | established | defunct |
|---|---|---|---|---|---|
| 59 | Michigan Territory | TERRITORY | 1 | 1805-06-30 | 1837-01-26 |
| 60 | Indiana Territory | TERRITORY | 1 | 1800-07-04 | 1816-12-11 |

Abbrevs left empty deliberately — the catalog only uses the ambiguous `M.T.` (your header doc: Michigan/Minnesota/Mississippi), and the eventual codes must not collide with 2-char state abbrevs since the munger keys catalogs to regions by filename prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
