### PR TITLE
Delaware E2E: single-dot leader munger fix + image-extract recovery (Issue 11 — 295 markings, 0 errors)

### DIFF
--- a/tools/munger/text_utils.py
+++ b/tools/munger/text_utils.py
@@ -2,6 +2,18 @@ import re
 
 
 def strip_dot_leaders(text):
-    """Remove runs of 2+ dots (dot leaders) and collapse resulting whitespace."""
+    """Remove dot leaders and collapse resulting whitespace.
+
+    Two leader forms occur: runs of 2+ dots (the common case), and a
+    single dot flanked by whitespace on both sides (a short leader the
+    extract emits when only a couple of dots were scanned, e.g.
+    ``Cantwells Bridge 1807,1810,1823,1846 . 150/75.00``). A space-
+    isolated single dot is always a leader -- abbreviation periods attach
+    to a letter/digit (``C.D.``, ``St.``, ``N.W.``), never sit space-
+    isolated -- so collapsing it is safe and leaves real abbreviations
+    untouched. Without this, the trailing leader residue survives value-
+    stripping and blocks the manuscript date peel, gluing the dates into
+    the post-office name."""
     t = re.sub(r'\.{2,}', ' ', str(text))
+    t = re.sub(r'(?<=\s)\.(?=\s)', ' ', t)
     return re.sub(r'  +', ' ', t).strip()

--- a/tools/test_munger_dotleaders.py
+++ b/tools/test_munger_dotleaders.py
@@ -1,0 +1,64 @@
+"""strip_dot_leaders: single space-isolated dot leaders (DE Issue #11).
+
+The extract sometimes emits a dot leader as a single '.' (when only a
+couple of dots were scanned) instead of the usual '...'. A space-isolated
+single dot is always a leader -- abbreviation periods attach to a
+letter/digit ('C.D.', 'St.', 'N.W.') and never sit space-flanked -- so it
+must collapse like a 2+ dot run. Without this, the trailing leader residue
+survives value-stripping and blocks the manuscript date peel, gluing the
+dates into the post-office name (e.g. 'Cantwells Bridge 1807,1810,...').
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from munger.text_utils import strip_dot_leaders
+
+
+class TestSingleDotLeaders(unittest.TestCase):
+    def test_single_dot_leader_before_value_collapses(self):
+        # The DE manuscript row that broke the munge.
+        self.assertEqual(
+            strip_dot_leaders(
+                "Cantwells Bridge ... 1807,1810,1823,1846 . 150/75.00"),
+            "Cantwells Bridge 1807,1810,1823,1846 150/75.00")
+
+    def test_single_dot_leader_before_value_handstamp(self):
+        # The sibling (VA/MI/FL/MD) handstamp form -- value leader.
+        self.assertEqual(
+            strip_dot_leaders("AYLETTS/Va.(1841-51;30;PAID;Red) . 25.00"),
+            "AYLETTS/Va.(1841-51;30;PAID;Red) 25.00")
+
+    def test_mid_string_leader_drives_inscription_fix(self):
+        # The VA catalog line whose inscription artifact this fix removes
+        # downstream (mid-string ' . ' between '(Co)' and the date).
+        self.assertEqual(
+            strip_dot_leaders("*Browns Store Franklin (Co) . 1813 --"),
+            "*Browns Store Franklin (Co) 1813 --")
+
+    def test_trailing_bare_dot_is_conservative(self):
+        # A dot with no following whitespace is NOT treated as a leader
+        # (could be meaningful); the fix only targets space-flanked dots.
+        self.assertEqual(strip_dot_leaders("Browns Store Franklin ."),
+                         "Browns Store Franklin .")
+
+    def test_abbreviation_periods_survive(self):
+        # Periods attached to letters are NOT leaders -- must be preserved.
+        for s in ["Duck C.D. 1798", "St. George", "N.W. Fork Bridge",
+                  "CHARLOTTE C.H./Va.(1845-56;30;PAID;Black)"]:
+            self.assertEqual(strip_dot_leaders(s), s, f"mangled: {s!r}")
+
+    def test_multi_dot_leader_unchanged_behavior(self):
+        # The original 2+ dot behavior is preserved.
+        self.assertEqual(strip_dot_leaders("Black Bird ... 1851 ... 150.00"),
+                         "Black Bird 1851 150.00")
+
+    def test_decimal_points_in_values_survive(self):
+        # A dot inside a number is not space-flanked -> untouched.
+        self.assertEqual(strip_dot_leaders("Same(SL-28x2.5;Black) 150.00"),
+                         "Same(SL-28x2.5;Black) 150.00")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Delaware (DE) — Issue #11, the 3rd state in the post-MI expansion (after FL #51, MD #52)

Runs the full ASCC pipeline against `DE_ASCC-CTG_ASCC-CTLG.pdf` → **295 markings / 80 post offices / 80 junctions**, imported `new=1253 error=0` into a separate local `worldcovers_de` DB. The **3-layer verification gate passed before commit/import with 0 production errors** (the cleanest run yet). The only repo change is one generic munger fix; the DE marking data lives in the per-state DB, not the repo (per ISSUE.md #34, until ID-offsetting).

### ⚠️ Branch stacking (read first)
This branch is `staging` + **cherry-picks of FL's `2a935a0` (TERRITORIAL PERIOD) and MD's `69c164e` (decade-suffix + `;`/`_`)** + this PR's own commit. DE needed both sibling capabilities, and neither is on `staging` yet. So **this PR's diff currently shows 3 commits**; the two cherry-picks **de-duplicate automatically once #51 and #52 merge to `staging` first**. The only DE-original commit is `1c448e4`.

---

## The code change — `1c448e4` `fix(munger): collapse single space-isolated dot leaders`

**Problem:** the manuscript-table row `Cantwells Bridge … 1807,1810,1823,1846 . 150/75.00` aborted the munge — `CANTWELLS BRIDGE 1807 1810 1823 1846` failed the post-office charset assertion (digits in the name).

**Cause:** the value dot-leader was rendered by the extract as a **single `.`** (not `...`). `strip_dot_leaders` only collapsed runs of 2+ dots, so the lone `.` survived; after value-stripping, the trailing ` .` blocked the manuscript date-peel and glued the dates into the town name.

**Fix:** collapse a single dot **flanked by whitespace on both sides** — always a leader, since abbreviation periods attach to a letter (`C.D.`, `St.`, `N.W.`) and never sit space-isolated. 6 new unit tests in `tools/test_munger_dotleaders.py`; full munger suite 17/17.

**Regression — please note this is NOT a pure no-op, unlike #51/#52's fixes.** Re-munging VA/MI/FL/MD with vs without this change is **byte-identical on all marking _data_** (post_offices, dates_seen, citations, colors, rates, shapes, images, junctions). The only diffs:
- `catalog_txt` (the stored display string) loses a stray ` . ` in ~600 sibling rows — **cosmetic**;
- **1 VA `inscription_txt` artifact is fixed**: `Browns Store Franklin .` → `Browns Store Franklin` (that it surfaced is evidence the change is correct).

No sibling re-import is implied; their live data is untouched. Reese approved keeping it.

---

## 3-layer verification (PASS, before commit)

- **L1 — deterministic reconstruction:** 24/24 chunks tile their 6 half-pages **pixel-exact**.
- **L2 — v1 oracle:** universe 154 content rows vs 152 extract listings; 99 exact + 25 near; **all 73 disputes dispositioned**. Most are colour/rate-order swaps (non-disputes — colour is an unordered set) or extract-richer annotations v1 dropped. **v1 errors found** (print-verified): SMYRNA Bee-like `1826-29`→`1828-29`, SMYRA `Blue`→`Brown`, NEWARK Same `1851-63`→`1851-54`, `Coach's`→`Cooch's`, plus manuscript-table date enrichment and two v1-only towns (`Williamsville`, `Lowes X Roads`) not in this print. Confirms FL/MD: **v1 is not print-faithful row-for-row.**
- **L3 — gpt-4o cross-model re-extraction:** 164 agree, 17 disagreements — 12 META formatting, **5 content all adjudicated production-correct** (`WLM.D` MDD, `Registered` 1851, `Duck C.D.` YMDD, `*Frederica` value `--`). The lone L3 "value" flag (`MILSBORO 150`) was an **88-char display-truncation artifact** in `l3_crossmodel.py`'s diff — the full string was `1500.00` all along. **0 production errors.**

---

## image-extract header-stranding — recovered without a shared-code change (root-cause fix proposed below)

Two chunks failed `marking_count_mismatch`, emitting 0 of their tracings (NEWCASTLE ×4, WILMINGTON). **Root cause (instrumented):** Stage 1 cuts the marking/text boundary at the _largest_ inter-block gap; when a town-name **header sits above the tracings** (`N CASTLE·D SEP 16`, `WILMINGTON·D`), the header→tracing gap exceeds the tracing→text gap, so the cut strands every tracing in the discarded region. (p42c9 also forms a 2-row grid the 1-D splitter can't partition.)

I researched the standard fix (recursive X-Y cut + figure/text classification) and **proved it doesn't transfer to this catalog**: the listing text isn't left-flush (dot-leader values fill the width), so width/centering classifiers mislabel; and the same visual slot is sometimes a marking (`N CASTLE·D SEP 16`, dated) and sometimes a header (`WILMINGTON·D`, undated) — only semantic understanding separates them. So I **recovered all 10 tracings via a documented review-stage crop** (split each human-identified illustration block at the N−1 widest blank-column gaps), **with zero change to `ascc_image_extract.py`** — siblings provably untouched. Also corrected a vision **over-count** (WILMINGTON `Images Above` 6→4; the header was counted as a marking). All 10 recovered tracings import and serve `200 image/png`.

**@Michael — proposed root-cause fix (separate, regression-gated PR):** set the Stage-1 boundary by reusing the chunk stage's already-persisted vision illustration/text classification (`<BASE>_blocks.json`, keyed by SHA-256 of each block PNG) instead of re-deriving it geometrically. This supersedes MD #52's "largest-gap forfeit" note with the deeper cause and would fix header-stranding + grids for every future state.

---

## Sibling protection (MI + FL + MD untouched — proven)
- DB counts **exact** after the DE import: MI `2617/837/876/93`, FL `946/302/328/86`, MD `1718/392/392/153`.
- A 2,031-file SHA-256 manifest over `tools/wip/` + `backend/media/` re-verified **2021/2031 OK**; all 10 changes are the shared-name bundle CSVs in `wip/out/` that every munge rewrites — **zero `VA_*`/`MI_*`/`FL_*`/`MD_*` chunk files, zero `media/{va,mi,fl,md}/` files**.

## Per-state data decisions
- **COLONIAL PERIOD → default Delaware (id 10):** DE went colony→state with no territory and `regions.csv` has no colony-tier DE region, so `COLONIAL`/`STATEHOOD` banners leave listings on the catalog default — as MI's `BRITISH COLONIAL PERIOD` and the FL/MD pre-statehood call. FL's `TERRITORIAL PERIOD` matcher correctly does **not** fire. No `regions.csv` change.

## Open tails for @Michael
- image-extract `blocks.json`-reuse fix (above) — the proper header-stranding/grid fix.
- WILMINGTON IA over-count — restore a 5th/6th tracing only if you read more than 4 illustrated marks on p.42.
- v1 row-for-row divergence (SMYRNA/SMYRA/NEWARK + ms-table enrichment) for the eventual v1-reconciliation.

## How to reproduce
```bash
# composed branch: staging + FL 2a935a0 + MD 69c164e + this fix
uv run python -m unittest tools.test_munger_dotleaders tools.test_munger_head_dates tools.test_munger_sections   # 17/17
# full pipeline per docs/PIPELINE.md against DE_ASCC_CTLG; import:
DB_NAME=worldcovers_de uv run python backend/manage.py migrate
DB_NAME=worldcovers_de uv run python backend/manage.py import_ascc_bundle ./tools/wip/out/   # new=1253 error=0
```

Verification evidence (logs, gpt-4o L3 CSV, adjudication zoom crops, recovery crops, sibling baseline manifest + DB snapshot, regression summary, API/media proof, `MANIFEST.sha256`) is archived in the workspace at `archives/de-verify-2026-06-13/` (60 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
