### PR TITLE
Issue #24: surface a town's full multi-territory history on the detail view

### DIFF
--- a/backend/common/api/v2/serializers.py
+++ b/backend/common/api/v2/serializers.py
@@ -571,6 +571,21 @@ def _marking_state_abbrev(marking) -> str:
     return (region.abbrev or "") if region else ""
 
 
+def _marking_regions(marking):
+    """All Regions for a marking's PostOffice (current-first), as serializable
+    dicts. Empty list when there is no post office. Mirrors the single-region
+    helpers above but exposes the town's full multi-territory history."""
+    if not getattr(marking, "post_office_id", None):
+        return []
+    post_office = getattr(marking, "post_office", None)
+    if post_office is None:
+        return []
+    return [
+        {"id": r.id, "name": r.name, "abbrev": r.abbrev, "region_tier": r.region_tier}
+        for r in post_office.regions
+    ]
+
+
 def _viewer_may_see_contribution_notes(user, contribution) -> bool:
     # contribution: Contribution | None. Returns True for any editor/admin/superuser
     # or the contributor who made it. False for anon and unrelated users. This is
@@ -715,6 +730,7 @@ class MarkingSerializer(serializers.ModelSerializer):
     state = serializers.SerializerMethodField()
     state_abbrev = serializers.SerializerMethodField()
     region_name = serializers.SerializerMethodField()
+    regions = serializers.SerializerMethodField()
     town = serializers.CharField(source="post_office.name", read_only=True, default="")
     shape_name = serializers.CharField(source="shape.name", read_only=True, default="")
     lettering_name = serializers.CharField(source="lettering.name", read_only=True, default="")
@@ -763,6 +779,7 @@ class MarkingSerializer(serializers.ModelSerializer):
             "color_name",
             "post_office_name",
             "region_name",
+            "regions",
             "earliest_seen",
             "earliest_seen_granularity",
             "latest_seen",
@@ -831,6 +848,9 @@ class MarkingSerializer(serializers.ModelSerializer):
 
     def get_region_name(self, obj):
         return _marking_state_name(obj)
+
+    def get_regions(self, obj):
+        return _marking_regions(obj)
 
     def get_images(self, obj):
         rows = Image.objects.filter(

--- a/backend/common/models.py
+++ b/backend/common/models.py
@@ -809,6 +809,26 @@ class PostOffice(TimestampedModel):
         )
         return link.region if link is not None else None
 
+    @property
+    def regions(self):
+        # All Regions this PostOffice is linked to via the post_office_regions
+        # junction, ordered the same way as .region: current/active first
+        # (defunct_date NULL via NULLS-FIRST), then most-recently established.
+        # Unlike .region (which collapses to one), this exposes a town's full
+        # multi-territory history -- e.g. Michigan Territory + Michigan -- so a
+        # town spanning several jurisdictions over time shows all of them.
+        return [
+            link.region
+            for link in (
+                self.post_office_regions
+                .select_related('region')
+                .order_by(
+                    F('region__defunct_date').desc(nulls_first=True),
+                    F('region__established_date').desc(nulls_last=True),
+                )
+            )
+        ]
+
 class PostOfficeRegion(TimestampedModel):
     """
     Association linking a PostOffice to a Region under whose jurisdiction

--- a/backend/common/tests/test_multi_territory_regions.py
+++ b/backend/common/tests/test_multi_territory_regions.py
@@ -1,0 +1,116 @@
+"""
+Multi-territory support (Issue #24).
+
+A PostOffice can be linked to several Regions over time via the
+post_office_regions junction (e.g. Michigan Territory + Michigan). The
+single-region `.region` property collapses that to one; `.regions` and the
+serializer's `regions` field must expose all of them, current/active first.
+"""
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from types import SimpleNamespace
+
+from common.api.v2.serializers import MarkingSerializer, _marking_regions
+from common.models import (
+    Color,
+    Marking,
+    PostOffice,
+    PostOfficeRegion,
+    Region,
+)
+
+User = get_user_model()
+
+
+class MultiTerritoryRegionsTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="ed", password="pw")
+        # Historical territory (defunct) + the state that succeeded it (active).
+        self.territory = Region.objects.create(
+            name="Michigan Territory",
+            abbrev="MIT",
+            region_tier="TERRITORY",
+            established_date=date(1805, 6, 30),
+            defunct_date=date(1837, 1, 26),
+            created_by=self.user,
+            modified_by=self.user,
+        )
+        self.state = Region.objects.create(
+            name="Michigan",
+            abbrev="MI",
+            region_tier="STATE",
+            established_date=date(1837, 1, 26),
+            defunct_date=None,  # active
+            created_by=self.user,
+            modified_by=self.user,
+        )
+        self.post_office = PostOffice.objects.create(
+            name="Detroit", created_by=self.user, modified_by=self.user
+        )
+        for region in (self.territory, self.state):
+            PostOfficeRegion.objects.create(
+                post_office=self.post_office,
+                region=region,
+                created_by=self.user,
+                modified_by=self.user,
+            )
+        self.color = Color.objects.create(
+            name="Black", created_by=self.user, modified_by=self.user
+        )
+
+    def _marking(self, post_office):
+        return Marking.objects.create(
+            type="TOWNMARK",
+            inscription_txt="DETROIT",
+            is_manuscript=True,
+            color=self.color,
+            post_office=post_office,
+            created_by=self.user,
+            modified_by=self.user,
+        )
+
+    def test_model_regions_lists_all_linked_current_first(self):
+        # .region still collapses to the single active region (back-compat)...
+        self.assertEqual(self.post_office.region, self.state)
+        # ...while .regions exposes the full history, active first.
+        names = [r.name for r in self.post_office.regions]
+        self.assertEqual(names, ["Michigan", "Michigan Territory"])
+
+    def test_serializer_exposes_all_regions_with_fields(self):
+        data = MarkingSerializer(self._marking(self.post_office)).data
+        # The single-region fields are unchanged (active region wins).
+        self.assertEqual(data["region_name"], "Michigan")
+        # The new list carries every territory the town belonged to.
+        self.assertEqual(
+            data["regions"],
+            [
+                {"id": self.state.id, "name": "Michigan", "abbrev": "MI",
+                 "region_tier": "STATE"},
+                {"id": self.territory.id, "name": "Michigan Territory",
+                 "abbrev": "MIT", "region_tier": "TERRITORY"},
+            ],
+        )
+
+    def test_single_region_and_no_post_office_edges(self):
+        # One link -> one-element list.
+        solo_po = PostOffice.objects.create(
+            name="Ypsilanti", created_by=self.user, modified_by=self.user
+        )
+        PostOfficeRegion.objects.create(
+            post_office=solo_po, region=self.state,
+            created_by=self.user, modified_by=self.user,
+        )
+        self.assertEqual(
+            MarkingSerializer(self._marking(solo_po)).data["regions"],
+            [{"id": self.state.id, "name": "Michigan", "abbrev": "MI",
+              "region_tier": "STATE"}],
+        )
+        # Defensive path: a marking with no post office yields [] (the DB
+        # forbids a null post_office on a real Marking, so use a stub).
+        self.assertEqual(
+            _marking_regions(SimpleNamespace(post_office_id=None, post_office=None)),
+            [],
+        )

--- a/frontend/src/pages/RecordDetail.tsx
+++ b/frontend/src/pages/RecordDetail.tsx
@@ -25,6 +25,7 @@ import {
   getMarkingChangelog,
   loadAssociatedCoversForMarking,
   normalizeImageUrl,
+  regionsDisplay,
   removeMarking,
   reorderImages,
   restoreMarking,
@@ -618,7 +619,7 @@ const RecordDetail = () => {
     {
       type: record.type,
       isManuscript: record.isManuscript,
-      state: record.state,
+      state: regionsDisplay(record),
       town: record.town,
       inscriptionTxt: record.inscriptionTxt,
       earliestSeen: earliestValue,

--- a/frontend/src/services/markings.regions.test.ts
+++ b/frontend/src/services/markings.regions.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Multi-territory support (Issue #24): a town can belong to several
+ * territories/states over time. The marking mapper must surface them as a
+ * `regions` list, and `regionsDisplay` must render all of them (current-first)
+ * for the "State/Territory" detail row, falling back to the single primary
+ * region when the list is absent (e.g. search-list payloads).
+ */
+import { mapApiMarkingToRecord, regionsDisplay } from "./markings";
+
+describe("multi-territory regions", () => {
+  it("maps the API regions array, dropping malformed entries", () => {
+    const record = mapApiMarkingToRecord({
+      id: 1,
+      type: "TOWNMARK",
+      region_name: "Michigan",
+      regions: [
+        { id: 5, name: "Michigan", abbrev: "MI", region_tier: "STATE" },
+        { id: 6, name: "Michigan Territory", abbrev: "MIT", region_tier: "TERRITORY" },
+        { id: null, name: "no-id dropped" },
+        { id: 7, name: "" },
+      ],
+    });
+    expect(record.regions).toEqual([
+      { id: 5, name: "Michigan", abbrev: "MI", regionTier: "STATE" },
+      { id: 6, name: "Michigan Territory", abbrev: "MIT", regionTier: "TERRITORY" },
+    ]);
+  });
+
+  it("defaults regions to [] when the payload omits them", () => {
+    expect(mapApiMarkingToRecord({ id: 2, type: "TOWNMARK" }).regions).toEqual([]);
+  });
+
+  describe("regionsDisplay", () => {
+    const region = (name: string) => ({ id: 1, name, abbrev: "", regionTier: "" });
+
+    it("joins every territory current-first when there are several", () => {
+      expect(
+        regionsDisplay({
+          state: "Michigan",
+          regions: [region("Michigan"), region("Michigan Territory")],
+        }),
+      ).toBe("Michigan, Michigan Territory");
+    });
+
+    it("shows the single region when there is one", () => {
+      expect(regionsDisplay({ state: "Michigan", regions: [region("Michigan")] })).toBe(
+        "Michigan",
+      );
+    });
+
+    it("falls back to the primary state when the list is empty", () => {
+      expect(regionsDisplay({ state: "Virginia", regions: [] })).toBe("Virginia");
+    });
+  });
+});

--- a/frontend/src/services/markings.ts
+++ b/frontend/src/services/markings.ts
@@ -244,6 +244,14 @@ export interface MarkingCitation {
   referenceWork: MarkingCitationReferenceWork | null;
 }
 
+/** One territory/state a town belonged to (multi-territory support, #24). */
+export interface MarkingRegion {
+  id: number;
+  name: string;
+  abbrev: string;
+  regionTier: string;
+}
+
 /** Canonical UI shape for a marking row (list or detail). */
 export interface MarkingRecord {
   id: number;
@@ -272,6 +280,9 @@ export interface MarkingRecord {
   colorName: string;
   postOfficeName: string;
   regionName: string;
+  // All territories/states this town belonged to over time (current-first).
+  // regionName/state remain the single primary region for back-compat.
+  regions: MarkingRegion[];
   earliestSeen: string | null;
   earliestSeenGranularity: string | null;
   latestSeen: string | null;
@@ -471,6 +482,32 @@ function mapCitationList(raw: unknown): MarkingCitation[] {
 }
 
 /**
+ * Display string for the "State/Territory" row: every territory a town belonged
+ * to, current-first, comma-separated (multi-territory support, #24). Falls back
+ * to the single primary region (`state`) when the regions list is absent (e.g.
+ * search-list payloads that don't include it). Exported for unit testing.
+ */
+export function regionsDisplay(
+  record: Pick<MarkingRecord, "regions" | "state">,
+): string {
+  const names = record.regions.map((r) => r.name.trim()).filter((n) => n !== "");
+  return names.length > 0 ? names.join(", ") : record.state;
+}
+
+function mapRegionList(raw: unknown): MarkingRegion[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((r): MarkingRegion | null => {
+      const o = (r && typeof r === "object" ? r : {}) as Record<string, unknown>;
+      const id = toIdOrNull(o.id);
+      const name = toStr(o.name);
+      if (id == null || !name) return null;
+      return { id, name, abbrev: toStr(o.abbrev), regionTier: toStr(o.region_tier) };
+    })
+    .filter((x): x is MarkingRegion => x !== null);
+}
+
+/**
  * Convert a /markings/ list or detail payload into MarkingRecord.
  * Single-pass mapper: snake_case in, camelCase out, no fallbacks. The API
  * is now the canonical shape; if a field is missing, the empty default is
@@ -512,6 +549,7 @@ export function mapApiMarkingToRecord(raw: unknown): MarkingRecord {
     colorName: toStr(o.color_name),
     postOfficeName: toStr(o.post_office_name),
     regionName: toStr(o.region_name),
+    regions: mapRegionList(o.regions),
     earliestSeen: typeof o.earliest_seen === "string" && o.earliest_seen ? o.earliest_seen : null,
     earliestSeenGranularity:
       typeof o.earliest_seen_granularity === "string" && o.earliest_seen_granularity


### PR DESCRIPTION
## Issue #24 — Multi-territory support (town ↔ many territories)

**Spike finding: this is already a many-to-many — no migration.** `PostOffice` ↔ `Region` runs through the `PostOfficeRegion` junction (`post_office_region`), present since `0001_initial`. `PostOffice` carries no region column by design; the munger already emits one junction row per distinct `(post office, section region)` pair (`tools/ascc_data_munger.py:1846` — e.g. Detroit → Northwest/Indiana/Michigan Territory + statehood); and search already traverses the junction (`backend/common/filters.py:147`). The only gap was the **read/display path**, which collapsed to a single region (`PostOffice.region` + every serializer reading through it).

### What this PR does (the display half)
- **`PostOffice.regions`** — all linked regions, current/active first (same ordering as the existing `.region` property, which is unchanged and still returns the single primary region for back-compat).
- **`regions`** list field on the detail `MarkingSerializer` (`{id, name, abbrev, region_tier}`), via a `_marking_regions` helper mirroring the existing single-region helpers.
- **Frontend** — `MarkingRegion` type + `mapRegionList`; `regionsDisplay()` renders every territory in the "State/Territory" detail row, comma-joined current-first, falling back to the single primary region when the list is absent (e.g. search-list payloads).

Rendered as a comma-joined names string to keep the shared `MarkingFieldRow.value: string` contract (used by both RecordDetail and ContributionDetail). Badge/tag styling is deferred to **#28 (territory tags)** to keep this PR small.

### Explicitly out of scope
The **import-fragmentation** half — a town splitting into two `PostOffice` rows when its `normalized_town` differs across territory vs. statehood sections (dedup key `(state_code, normalized_town)`, `ascc_data_munger.py:1804`; the MI "173/837 territory-suffix" fragmentation / **Adamsville**). That fix lives in munger town normalization, changes import output, and is gated behind the MD/MI re-run — tracked separately.

### Tests / verification
- Backend +3 (`test_multi_territory_regions.py`): `.regions` ordering, serializer `regions` fields, single/no-PO edges.
- Frontend +5 (`markings.regions.test.ts`): mapper drops malformed entries / defaults `[]`; `regionsDisplay` multi/single/empty.
- Full suites green: **backend 84/84, frontend 30/30**, `tsc --noEmit` clean.
- `makemigrations --check` clean for this change (no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)