### PR TITLE
feat(#30): move Clear Filters to filter-panel header

### DIFF
--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -703,14 +703,25 @@ const Search = () => {
                 <CardContent className="pt-6 space-y-4">
                   <div className="flex items-center justify-between mb-4">
                     <h2 className="font-heading text-lg font-semibold">Filters</h2>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="lg:hidden"
-                      onClick={() => setFiltersOpen(false)}
-                    >
-                      Close
-                    </Button>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-auto p-0 text-sm font-normal text-muted-foreground hover:text-foreground"
+                        onClick={handleClearAllFilters}
+                        disabled={filtersDisabled}
+                      >
+                        Clear filters
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="lg:hidden"
+                        onClick={() => setFiltersOpen(false)}
+                      >
+                        Close
+                      </Button>
+                    </div>
                   </div>
 
                   <div className="space-y-2">
@@ -1049,15 +1060,6 @@ const Search = () => {
                       </label>
                     </div>
                   </div>
-
-                  <Button
-                    variant="outline"
-                    className="w-full"
-                    onClick={handleClearAllFilters}
-                    disabled={filtersDisabled}
-                  >
-                    Clear Filters
-                  </Button>
                 </CardContent>
               </Card>
             </aside>


### PR DESCRIPTION
Implements **issue #30** from Ian's 18-Jun email: *"Move clear filter to the top."*

## What
Relocates the **Clear Filters** control from the bottom of the Search filter sidebar into the **"Filters" header row** (right-aligned, compact ghost button next to the mobile Close button), so it's reachable without scrolling past every filter field.

## How
- `frontend/src/pages/Search.tsx`: moved the button into the header `<div>`; removed the full-width bottom button. Reuses the existing `handleClearAllFilters`; keeps the `disabled={filtersDisabled}` guard.

## Scope / risk
Pure JSX relocation — no backend, no schema, no new deps, behavior unchanged.

## Tests
No dedicated test (relocation of an existing button on the untested `Search.tsx`; Pareto). Gates: tsc clean, eslint clean (1 pre-existing unrelated warning), jest 45/45, vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)