### PR TITLE
feat(#28): territory/state tags on detail + searchable

### DIFF
--- a/frontend/src/components/MarkingFieldsDisplay.tsx
+++ b/frontend/src/components/MarkingFieldsDisplay.tsx
@@ -1,5 +1,7 @@
+import { Link } from "react-router-dom";
 import type { MarkingFieldRow } from "@/lib/markingFields";
 import { hasDisplayValue } from "@/lib/markingFields";
+import { Badge } from "@/components/ui/badge";
 
 const EMPTY = "-";
 
@@ -26,9 +28,30 @@ export function MarkingFieldsDisplay({ rows, mode }: Props) {
           className={`flex justify-between py-2 ${idx === visible.length - 1 ? "" : "border-b border-border"}`}
         >
           <dt className="text-muted-foreground font-medium">{row.label}</dt>
-          <dd className="text-foreground whitespace-pre-line text-right">
-            {row.value && row.value.trim() !== "" ? row.value : EMPTY}
-          </dd>
+          {row.tags && row.tags.length > 0 ? (
+            <dd className="flex flex-wrap gap-1.5 justify-end">
+              {row.tags.map((tag, tagIdx) =>
+                tag.to ? (
+                  <Link key={`${tag.label}-${tagIdx}`} to={tag.to}>
+                    <Badge
+                      variant="secondary"
+                      className="cursor-pointer hover:bg-secondary/80"
+                    >
+                      {tag.label}
+                    </Badge>
+                  </Link>
+                ) : (
+                  <Badge key={`${tag.label}-${tagIdx}`} variant="secondary">
+                    {tag.label}
+                  </Badge>
+                ),
+              )}
+            </dd>
+          ) : (
+            <dd className="text-foreground whitespace-pre-line text-right">
+              {row.value && row.value.trim() !== "" ? row.value : EMPTY}
+            </dd>
+          )}
         </div>
       ))}
     </dl>

--- a/frontend/src/lib/markingFields.test.ts
+++ b/frontend/src/lib/markingFields.test.ts
@@ -53,3 +53,39 @@ describe("buildMarkingFields — Dates Seen row (issue #25)", () => {
     expect(labels.indexOf("Dates Seen")).toBe(labels.indexOf("Latest Seen") + 1);
   });
 });
+
+describe("buildMarkingFields — State/Territory tags (issue #28)", () => {
+  it("attaches region tags (search links) to the State/Territory row when supplied", () => {
+    const rows = buildMarkingFields(
+      baseInput({
+        state: "Michigan, Michigan Territory",
+        regionTags: [
+          { label: "Michigan", to: "/search?state=Michigan" },
+          { label: "Michigan Territory", to: "/search?state=Michigan%20Territory" },
+        ],
+      }),
+      { isStaff: false },
+    );
+    const row = rows.find((r) => r.label === "State/Territory");
+    expect(row?.tags).toHaveLength(2);
+    expect(row?.tags?.[0]).toEqual({ label: "Michigan", to: "/search?state=Michigan" });
+    // value is kept as the comma-joined fallback (visibility key + ContributionDetail).
+    expect(row?.value).toBe("Michigan, Michigan Territory");
+  });
+
+  it("leaves tags undefined when no region tags are supplied (ContributionDetail path)", () => {
+    const rows = buildMarkingFields(baseInput({ state: "Virginia" }), { isStaff: false });
+    const row = rows.find((r) => r.label === "State/Territory");
+    expect(row?.tags).toBeUndefined();
+    expect(row?.value).toBe("Virginia");
+  });
+
+  it("treats an empty regionTags array as no tags (falls back to the value string)", () => {
+    const rows = buildMarkingFields(
+      baseInput({ state: "Virginia", regionTags: [] }),
+      { isStaff: false },
+    );
+    const row = rows.find((r) => r.label === "State/Territory");
+    expect(row?.tags).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/markingFields.ts
+++ b/frontend/src/lib/markingFields.ts
@@ -5,6 +5,13 @@
 
 import type { MarkingTypeValue } from "@/services/markings";
 
+// A chip rendered in place of a row's plain-text value. `to`, when set, makes
+// the chip a router Link (e.g. a territory tag that runs a filtered search).
+export interface MarkingFieldTag {
+  label: string;
+  to?: string;
+}
+
 export interface MarkingFieldRow {
   label: string;
   // Pre-formatted display string. "" means blank; the renderer decides
@@ -14,12 +21,21 @@ export interface MarkingFieldRow {
   // hasDisplayValue filter even when blank). ContributionDetail ignores it
   // and shows every row.
   alwaysShow: boolean;
+  // When non-empty, the renderer shows these chips instead of `value`. `value`
+  // is still the visibility key (hasDisplayValue) and the fallback when no tags
+  // are supplied (e.g. ContributionDetail). (issue #28)
+  tags?: MarkingFieldTag[];
 }
 
 export interface MarkingFieldInput {
   type: MarkingTypeValue | null;
   isManuscript: boolean;
   state: string;
+  // All territory/state affiliations as chips for the State/Territory row,
+  // current-first. Optional: only RecordDetail supplies them (from
+  // record.regions); ContributionDetail omits them and the comma-joined
+  // `state` string renders instead. (issue #28)
+  regionTags?: MarkingFieldTag[];
   town: string;
   inscriptionTxt: string;
   // Already formatted according to DateSeen granularity.
@@ -71,7 +87,12 @@ export function buildMarkingFields(
   const rows: MarkingFieldRow[] = [
     { label: "Type", value: typeLabel(i.type), alwaysShow: false },
     { label: "Manuscript", value: i.isManuscript ? "Yes" : "No", alwaysShow: false },
-    { label: "State/Territory", value: i.state, alwaysShow: false },
+    {
+      label: "State/Territory",
+      value: i.state,
+      alwaysShow: false,
+      tags: i.regionTags && i.regionTags.length > 0 ? i.regionTags : undefined,
+    },
     { label: "Town", value: i.town, alwaysShow: false },
     { label: inscriptionLabel(i.type), value: i.inscriptionTxt, alwaysShow: false },
     { label: "Earliest Seen", value: i.earliestSeen, alwaysShow: true },

--- a/frontend/src/pages/RecordDetail.tsx
+++ b/frontend/src/pages/RecordDetail.tsx
@@ -645,6 +645,13 @@ const RecordDetail = () => {
       type: record.type,
       isManuscript: record.isManuscript,
       state: regionsDisplay(record),
+      // Each territory/state becomes a chip linking to a region-filtered
+      // search. The Search page's `state` param matches on region name, and
+      // its filter traverses the post_office_regions M2M. (issue #28)
+      regionTags: record.regions.map((r) => ({
+        label: r.name,
+        to: `/search?state=${encodeURIComponent(r.name)}`,
+      })),
       town: record.town,
       inscriptionTxt: record.inscriptionTxt,
       earliestSeen: earliestValue,


### PR DESCRIPTION
Implements **issue #28** from Ian's 18-Jun email: *"Territory and state etc tags that show on the detail screen and searchable."*

## What
On the marking detail screen, a town's territory/state affiliations now render as **clickable `Badge` chips** (one per region, current-first) instead of a comma-joined string. Each chip links to `/search?state=<name>`, running a region-filtered search — unifying *tags* and *searchable*.

Search-by-region itself already worked (the `state` filter traverses the `post_office_regions` M2M and matches name or abbrev); this PR adds the tag display + the tags→search link.

## How
- `lib/markingFields.ts`: optional `tags` on `MarkingFieldRow` + optional `regionTags` input on `buildMarkingFields`.
- `components/MarkingFieldsDisplay.tsx`: renders chips when `tags` present, else the plain value (so `ContributionDetail`, which passes no tags, is unchanged).
- `pages/RecordDetail.tsx`: builds region tags from `record.regions` (from #24).

## Scope / risk
Frontend only — no backend/schema/migration. Builds on #24 (multi-territory display), now merged.

## Tests
+3 in `markingFields.test.ts` (tags attached / undefined / empty-array fallback). Gates: tsc/eslint clean, jest 45/45, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)