### PR TITLE
feat(#29): make institutional records searchable

### DIFF
--- a/backend/common/filters.py
+++ b/backend/common/filters.py
@@ -76,6 +76,10 @@ class MarkingListFilter(django_filters.FilterSet):
         label='Shape id',
     )
     has_images = django_filters.CharFilter(method='filter_has_images', label='Has images')
+    institutional = django_filters.CharFilter(
+        method='filter_institutional',
+        label='Has an institutionally owned cover',
+    )
     reference_work_code = django_filters.CharFilter(
         method='filter_by_reference_work_code',
         label='Reference work code',
@@ -169,6 +173,22 @@ class MarkingListFilter(django_filters.FilterSet):
             subject_type=Image.SUBJECT_MARKING,
         ).values_list('subject_id', flat=True)
         return queryset.filter(pk__in=marking_ids_with_images)
+
+    @staticmethod
+    def filter_institutional(queryset, name, value):
+        # "Institutional" lives on Cover (is_institutional); a marking counts as
+        # institutional when at least one of its covers is institutionally
+        # owned. Route through Cover.objects (the default manager) so
+        # recycle-binned covers are excluded -- an FK traversal like
+        # cover__is_institutional=True would use base_manager_name='all_objects'
+        # and wrongly include removed covers. (issue #29)
+        if not value or str(value).strip().lower() != 'true':
+            return queryset
+        from .models import Cover, CoverMarking
+        institutional_marking_ids = CoverMarking.objects.filter(
+            cover__in=Cover.objects.filter(is_institutional=True),
+        ).values_list('marking_id', flat=True)
+        return queryset.filter(pk__in=institutional_marking_ids)
 
     @staticmethod
     def filter_by_reference_work_code(queryset, name, value):

--- a/backend/common/tests/test_marking_institutional_filter.py
+++ b/backend/common/tests/test_marking_institutional_filter.py
@@ -1,0 +1,113 @@
+"""
+Issue #29 -- "institutional" search filter on the markings list.
+
+"Institutional" lives on Cover (is_institutional); a marking is institutional
+when at least one of its non-removed covers is. Covers the load-bearing slice:
+the filter selects only markings with an institutional cover, excludes
+recycle-binned covers, and is a no-op when blank/absent.
+"""
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from common.models import (
+    Color,
+    Cover,
+    CoverMarking,
+    CoverRecycleBin,
+    Marking,
+    PostOffice,
+)
+
+
+User = get_user_model()
+
+
+def _result_ids(response):
+    return {row["id"] for row in response.data["results"]}
+
+
+class MarkingInstitutionalFilterTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = User.objects.create_superuser(
+            "admin", email="admin@example.com", password="pw"
+        )
+        self.color = Color.objects.create(
+            name="Black", created_by=self.admin, modified_by=self.admin
+        )
+        self.post_office = PostOffice.objects.create(
+            name="Richmond", created_by=self.admin, modified_by=self.admin
+        )
+
+        # Three markings: one with an institutional cover, one with a
+        # non-institutional cover, one whose only institutional cover is
+        # recycle-binned (must NOT count).
+        self.inst_marking = self._marking("institutional")
+        self.plain_marking = self._marking("plain")
+        self.removed_marking = self._marking("removed-institutional")
+
+        inst_cover = self._cover(is_institutional=True)
+        plain_cover = self._cover(is_institutional=False)
+        removed_cover = self._cover(is_institutional=True)
+        # Soft-remove the institutional cover by putting it in the recycle bin.
+        CoverRecycleBin.objects.create(cover=removed_cover, removed_by=self.admin)
+
+        self._link(self.inst_marking, inst_cover)
+        self._link(self.plain_marking, plain_cover)
+        self._link(self.removed_marking, removed_cover)
+
+    def _marking(self, text):
+        return Marking.objects.create(
+            type="TOWNMARK",
+            catalog_txt=text,
+            inscription_txt=text,
+            desc="",
+            is_manuscript=True,
+            color=self.color,
+            post_office=self.post_office,
+            created_by=self.admin,
+            modified_by=self.admin,
+        )
+
+    def _cover(self, *, is_institutional):
+        return Cover.objects.create(
+            is_institutional=is_institutional,
+            created_by=self.admin,
+            modified_by=self.admin,
+        )
+
+    def _link(self, marking, cover):
+        return CoverMarking.objects.create(
+            marking=marking,
+            cover=cover,
+            created_by=self.admin,
+            modified_by=self.admin,
+        )
+
+    def test_institutional_true_returns_only_markings_with_institutional_cover(self):
+        response = self.client.get(
+            "/api/v2/markings/", {"institutional": "true", "page_size": "50"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(_result_ids(response), {self.inst_marking.id})
+
+    def test_recycle_binned_institutional_cover_does_not_count(self):
+        response = self.client.get(
+            "/api/v2/markings/", {"institutional": "true", "page_size": "50"}
+        )
+        self.assertNotIn(self.removed_marking.id, _result_ids(response))
+
+    def test_blank_or_absent_does_not_filter(self):
+        all_ids = {
+            self.inst_marking.id,
+            self.plain_marking.id,
+            self.removed_marking.id,
+        }
+        blank = self.client.get(
+            "/api/v2/markings/", {"institutional": "", "page_size": "50"}
+        )
+        self.assertEqual(_result_ids(blank) & all_ids, all_ids)
+
+        absent = self.client.get("/api/v2/markings/", {"page_size": "50"})
+        self.assertEqual(_result_ids(absent) & all_ids, all_ids)

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -282,6 +282,9 @@ const Search = () => {
     return "both";
   });
   const [imagesOnly, setImagesOnly] = useState(() => getSearchParam(searchParams, "images", "") === "true");
+  const [institutionalOnly, setInstitutionalOnly] = useState(
+    () => getSearchParam(searchParams, "institutional", "") === "true",
+  );
   const [reviewedFilter, setReviewedFilter] = useState<"all" | "reviewed" | "unreviewed">(() => {
     const raw = getSearchParam(searchParams, "reviewed", "");
     return raw === "reviewed" || raw === "unreviewed" ? raw : "all";
@@ -341,6 +344,7 @@ const Search = () => {
   const prevHeightFilterRef = useRef("");
   const prevWidthFilterRef = useRef("");
   const prevImagesOnlyRef = useRef(imagesOnly);
+  const prevInstitutionalOnlyRef = useRef(institutionalOnly);
   const prevManuscriptFilterRef = useRef(manuscriptFilter);
   const prevReviewedFilterRef = useRef(reviewedFilter);
   const prevTypeFilterRef = useRef(typeFilter);
@@ -420,6 +424,7 @@ const Search = () => {
     const heightFilterJustChanged = prevHeightFilterRef.current !== currentNormalizedHeight;
     const widthFilterJustChanged = prevWidthFilterRef.current !== currentNormalizedWidth;
     const imagesOnlyJustChanged = prevImagesOnlyRef.current !== imagesOnly;
+    const institutionalOnlyJustChanged = prevInstitutionalOnlyRef.current !== institutionalOnly;
     const manuscriptFilterJustChanged = prevManuscriptFilterRef.current !== manuscriptFilter;
     const reviewedFilterJustChanged = prevReviewedFilterRef.current !== reviewedFilter;
     const typeFilterJustChanged = prevTypeFilterRef.current !== typeFilter;
@@ -436,6 +441,7 @@ const Search = () => {
     if (heightFilterJustChanged) prevHeightFilterRef.current = currentNormalizedHeight;
     if (widthFilterJustChanged) prevWidthFilterRef.current = currentNormalizedWidth;
     if (imagesOnlyJustChanged) prevImagesOnlyRef.current = imagesOnly;
+    if (institutionalOnlyJustChanged) prevInstitutionalOnlyRef.current = institutionalOnly;
     if (manuscriptFilterJustChanged) prevManuscriptFilterRef.current = manuscriptFilter;
     if (reviewedFilterJustChanged) prevReviewedFilterRef.current = reviewedFilter;
     if (typeFilterJustChanged) prevTypeFilterRef.current = typeFilter;
@@ -454,6 +460,7 @@ const Search = () => {
       heightFilterJustChanged ||
       widthFilterJustChanged ||
       imagesOnlyJustChanged ||
+      institutionalOnlyJustChanged ||
       manuscriptFilterJustChanged ||
       reviewedFilterJustChanged ||
       typeFilterJustChanged ||
@@ -462,7 +469,7 @@ const Search = () => {
     if (anyFilterChanged) {
       setCurrentPage(1);
     }
-  }, [debouncedKeywordSearch, shapeFilter, stateFilter, debouncedTownFilter, referenceWorkFilter, debouncedBeginYear, debouncedEndYear, debouncedHeightFilter, debouncedWidthFilter, imagesOnly, colorFilter, manuscriptFilter, reviewedFilter, typeFilter, submissionQueueSort, catalogSortKey]);
+  }, [debouncedKeywordSearch, shapeFilter, stateFilter, debouncedTownFilter, referenceWorkFilter, debouncedBeginYear, debouncedEndYear, debouncedHeightFilter, debouncedWidthFilter, imagesOnly, institutionalOnly, colorFilter, manuscriptFilter, reviewedFilter, typeFilter, submissionQueueSort, catalogSortKey]);
 
   // Treat years as active filters only when they are valid and 4 digits.
   const normalizedBeginYear = useMemo(() => {
@@ -543,6 +550,7 @@ const Search = () => {
       normalizedHeight,
       normalizedWidth,
       imagesOnly,
+      institutionalOnly,
       colorFilter,
       manuscriptFilter,
       reviewedFilter,
@@ -573,6 +581,7 @@ const Search = () => {
           height: normalizedHeight || undefined,
           width: normalizedWidth || undefined,
           hasImages: imagesOnly,
+          institutional: institutionalOnly,
           reviewed: reviewedFilter !== "all" ? reviewedFilter : undefined,
           ordering: orderingParamForSort(catalogSort),
         }
@@ -633,6 +642,7 @@ const Search = () => {
     if (colorFilter !== "all") params.set("color", colorFilter);
     if (manuscriptFilter !== "both") params.set("manuscripts", manuscriptFilter);
     if (imagesOnly) params.set("images", "true");
+    if (institutionalOnly) params.set("institutional", "true");
     if (reviewedFilter !== "all") params.set("reviewed", reviewedFilter);
     if (submissionQueueSort !== "newest") params.set("sort", submissionQueueSort);
     // Empty list (user toggled off all sorts) -> persist as the sentinel
@@ -645,7 +655,7 @@ const Search = () => {
     if (next !== current) {
       setSearchParams(next ? params : {}, { replace: true });
     }
-  }, [currentPage, debouncedKeywordSearch, stateFilter, debouncedTownFilter, referenceWorkFilter, normalizedBeginYear, normalizedEndYear, normalizedHeight, normalizedWidth, shapeFilter, typeFilter, colorFilter, manuscriptFilter, imagesOnly, reviewedFilter, submissionQueueSort, catalogSort, catalogSortKey, itemsPerPage, searchParams, setSearchParams]);
+  }, [currentPage, debouncedKeywordSearch, stateFilter, debouncedTownFilter, referenceWorkFilter, normalizedBeginYear, normalizedEndYear, normalizedHeight, normalizedWidth, shapeFilter, typeFilter, colorFilter, manuscriptFilter, imagesOnly, institutionalOnly, reviewedFilter, submissionQueueSort, catalogSort, catalogSortKey, itemsPerPage, searchParams, setSearchParams]);
 
   const totalPages = Math.ceil(totalCount / itemsPerPage) || 1;
   const pageStart = (currentPage - 1) * itemsPerPage;
@@ -672,6 +682,7 @@ const Search = () => {
     setValuationFilter("all");
     setManuscriptFilter("both");
     setImagesOnly(false);
+    setInstitutionalOnly(false);
     setReviewedFilter("all");
     setSubmissionQueueSort("newest");
     setCatalogSort([...DEFAULT_SORT]);
@@ -1046,6 +1057,20 @@ const Search = () => {
                         className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                       >
                         Images Only
+                      </label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        disabled={filtersDisabled}
+                        id="institutionalOnly"
+                        checked={institutionalOnly}
+                        onCheckedChange={(checked) => setInstitutionalOnly(checked as boolean)}
+                      />
+                      <label
+                        htmlFor="institutionalOnly"
+                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                      >
+                        Institutional Only
                       </label>
                     </div>
                   </div>

--- a/frontend/src/services/markings.ts
+++ b/frontend/src/services/markings.ts
@@ -616,6 +616,7 @@ export async function getMarkingsPage(
     height?: string;
     width?: string;
     hasImages?: boolean;
+    institutional?: boolean;
     referenceWorkCode?: string;
     reviewed?: "reviewed" | "unreviewed";
     deferCount?: boolean;
@@ -639,6 +640,7 @@ export async function getMarkingsPage(
   if (opt.height?.trim()) params.height = opt.height.trim();
   if (opt.width?.trim()) params.width = opt.width.trim();
   if (opt.hasImages === true) params.has_images = "true";
+  if (opt.institutional === true) params.institutional = "true";
   if (opt.referenceWorkCode?.trim()) params.reference_work_code = opt.referenceWorkCode.trim();
   if (opt.reviewed === "reviewed") params.reviewed = "true";
   else if (opt.reviewed === "unreviewed") params.reviewed = "false";


### PR DESCRIPTION
Implements the un-gated half of **issue #29** from Ian's 18-Jun email: *"Make sure that institutional appears."*

## Context (spike)
`Cover.is_institutional` already **displays** everywhere it's wired (Cover detail, marking detail per-cover, Django admin) and is settable in CoverEdit/CoverDialog. The real gap is that it's **not findable** in search — and (separately) the import never *sets* the flag. This PR ships the findability half.

## What
- New `institutional` filter on `MarkingListFilter`: `institutional=true` returns only markings with **at least one non-removed institutional cover**. The join routes through `Cover.objects` (default manager) so recycle-binned covers are excluded — an FK traversal would use `base_manager_name='all_objects'` and wrongly include them.
- "Institutional Only" checkbox in the Search sidebar, wired through the same state/URL-param/page-reset/clear-all plumbing as "Images Only"; service gains an `institutional` option → query param.

## Out of scope
The import/notation half (flag institutional from catalog notation) folds into **#37** — re-run-gated and needs a notation spec (the MI `*` is already used as the "first-of-town" marker).

## Tests
+3 backend (`test_marking_institutional_filter`): only-institutional, recycle-bin exclusion, blank-is-noop. Full common suite green. No schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)