### PR TITLE
feat(#27): gate marking ERD/LRD date entry to state editors

### DIFF
--- a/backend/common/api/v2/views.py
+++ b/backend/common/api/v2/views.py
@@ -45,7 +45,12 @@ from common.catalog_codes import (
     suggest_direct_catalog_code,
     suggest_for_contribution,
 )
-from common.contribution_apply import ContributionApplyError, _parse_int
+from common.contribution_apply import (
+    ContributionApplyError,
+    MARKING_DATE_SUBMIT_KEYS,
+    _parse_int,
+    strip_marking_date_keys,
+)
 from common.audit import (
     build_cover_snapshot,
     build_marking_snapshot,
@@ -2339,6 +2344,10 @@ class ContributionSubmitView(APIView):
         )
         if not user_can_submit_catalog_code:
             skip_keys.update(CATALOG_CODE_KEYS)
+            # ERD/LRD on Submit New Marking are editor-only (issue #27); the
+            # same editor role gates both. Drop them from a non-editor's
+            # submission so only an editor can set a marking's date.
+            skip_keys.update(MARKING_DATE_SUBMIT_KEYS)
         for key in data:
             if key in skip_keys:
                 continue
@@ -2440,6 +2449,7 @@ class ContributionSubmitView(APIView):
             submitted_data.update(image_updates)
             if not user_can_submit_catalog_code:
                 existing_sd = strip_catalog_code_keys(existing_sd)
+                existing_sd = strip_marking_date_keys(existing_sd)
             existing_sd.update(submitted_data)
             contrib.submitted_data = existing_sd
             contrib.collection = collection

--- a/backend/common/contribution_apply.py
+++ b/backend/common/contribution_apply.py
@@ -1069,6 +1069,24 @@ def _sync_cover_date_seen(cover_id, payload: dict, actor) -> None:
     )
 
 
+# Form keys carrying a manually-entered marking ERD/LRD (+ granularity), read
+# by _sync_marking_dates_seen below. Setting a marking's date is editor-only
+# (issue #27): the contribution submit handler strips these from a non-editor's
+# submission, exactly as it strips CATALOG_CODE_KEYS. Kept here, next to the
+# code that consumes them, so the key list has one home.
+MARKING_DATE_SUBMIT_KEYS = frozenset({
+    "marking_erd",
+    "marking_erd_granularity",
+    "marking_lrd",
+    "marking_lrd_granularity",
+})
+
+
+def strip_marking_date_keys(data: dict) -> dict:
+    """Drop manually-entered marking date keys (editor-only; issue #27)."""
+    return {k: v for k, v in data.items() if k not in MARKING_DATE_SUBMIT_KEYS}
+
+
 def _sync_marking_dates_seen(marking_id, payload: dict, actor) -> None:
     """
     Record manually-entered ERD/LRD as MARKING-subject DateSeen rows from

--- a/backend/common/tests/test_contribution_submit.py
+++ b/backend/common/tests/test_contribution_submit.py
@@ -213,6 +213,61 @@ class ContributionSubmitMarkingEditTests(TestCase):
         contribution = Contribution.objects.get(pk=response.data["id"])
         self.assertEqual(contribution.submitted_data["catalog_code"], "APMC-VA-M0001")
 
+    def test_contributor_submitted_marking_date_keys_are_stripped(self):
+        # Setting a marking's date is editor-only (issue #27): a contributor's
+        # ERD/LRD must not survive into submitted_data.
+        response = self.client.post(
+            "/api/v2/contributions/",
+            {
+                "state": "VA",
+                "town": "Richmond",
+                "type": "TOWNMARK",
+                "color": "Black",
+                "color_id": self.color.pk,
+                "is_manuscript": True,
+                "inscription_txt": "RICHMOND VA",
+                "marking_erd": "1845-01-01",
+                "marking_erd_granularity": "DAY",
+                "marking_lrd": "1850-12-31",
+                "marking_lrd_granularity": "DAY",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        contribution = Contribution.objects.get(pk=response.data["id"])
+        self.assertNotIn("marking_erd", contribution.submitted_data)
+        self.assertNotIn("marking_erd_granularity", contribution.submitted_data)
+        self.assertNotIn("marking_lrd", contribution.submitted_data)
+        self.assertNotIn("marking_lrd_granularity", contribution.submitted_data)
+
+    def test_editor_submitted_marking_dates_are_preserved(self):
+        editor = self._editor("submit-date-editor")
+        self.client.force_authenticate(editor)
+
+        response = self.client.post(
+            "/api/v2/contributions/",
+            {
+                "state": "VA",
+                "town": "Richmond",
+                "type": "TOWNMARK",
+                "color": "Black",
+                "color_id": self.color.pk,
+                "is_manuscript": True,
+                "inscription_txt": "RICHMOND VA",
+                "marking_erd": "1845-01-01",
+                "marking_erd_granularity": "DAY",
+                "marking_lrd": "1850-12-31",
+                "marking_lrd_granularity": "DAY",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        contribution = Contribution.objects.get(pk=response.data["id"])
+        self.assertEqual(contribution.submitted_data["marking_erd"], "1845-01-01")
+        self.assertEqual(contribution.submitted_data["marking_lrd"], "1850-12-31")
+
     def test_direct_marking_suggestion_uses_apmc_without_reference(self):
         editor = User.objects.create_superuser(
             username="direct-editor",

--- a/frontend/src/pages/Contribute.tsx
+++ b/frontend/src/pages/Contribute.tsx
@@ -1482,11 +1482,13 @@ const Contribute = () => {
         if (!isManuscriptSelected && letteringId) form.append("lettering_style_id", letteringId);
         if (!isManuscriptSelected && letteringId) form.append("lettering_id", letteringId);
         if (showDateFormatField && dateFmtCode) form.append("date_fmt", dateFmtCode);
-        if (erdToSend) {
+        // ERD/LRD are editor-only (issue #27): never send them from a
+        // non-editor, even if stale state lingers. The server also strips them.
+        if (isStateEditor && erdToSend) {
           form.append("marking_erd", erdToSend.date);
           form.append("marking_erd_granularity", erdToSend.granularity);
         }
-        if (lrdToSend) {
+        if (isStateEditor && lrdToSend) {
           form.append("marking_lrd", lrdToSend.date);
           form.append("marking_lrd_granularity", lrdToSend.granularity);
         }
@@ -2242,7 +2244,10 @@ const Contribute = () => {
                       </DropdownMenu>
                       {fieldErrors.dateFormat && <p className="text-sm text-destructive">{fieldErrors.dateFormat}</p>}
                     </div>}
-                    <div className="space-y-2">
+                    {/* Setting a marking's date is editor-only (issue #27); the
+                        field is hidden for non-editors and the server strips
+                        ERD/LRD from a non-editor's submission. */}
+                    {isStateEditor && <div className="space-y-2">
                       <Label>Recorded date range</Label>
                       <p className="text-sm text-muted-foreground">
                         Optional. Earliest (ERD) and latest (LRD) recorded dates for a
@@ -2280,7 +2285,7 @@ const Contribute = () => {
                         </div>
                       </div>
                       {fieldErrors.lrd && <p className="text-sm text-destructive">{fieldErrors.lrd}</p>}
-                    </div>
+                    </div>}
                     <div className="space-y-2">
                       <Label htmlFor="description">Description</Label>
                       <Textarea


### PR DESCRIPTION
Implements **issue #27** from Ian's 18-Jun email: *"Add date to new marking but only for state editors."*

A refinement of #21 Group C, which added the ERD/LRD ("Recorded date range") inputs to Submit New Marking with **no role gate**. This restricts *setting* a marking's date to editors, mirroring the existing **catalog-code** editor-only field exactly — two layers:

## How
- **Frontend** (`Contribute.tsx`): the "Recorded date range" block renders only when `isStateEditor` (the same flag that gates the catalog-code field via `canEditCatalogCode`); the submit append sends ERD/LRD only for editors.
- **Backend** (`views.py` submit handler): new `MARKING_DATE_SUBMIT_KEYS` + `strip_marking_date_keys` (in `contribution_apply.py`, beside the code that reads them) are added to `skip_keys` / stripped from `existing_sd` for non-editors — exactly where `CATALOG_CODE_KEYS` / `strip_catalog_code_keys` already are, reusing the same role test. **Authorization is enforced server-side, not just by hiding the input.**

No read-path strip (unlike catalog code): ERD/LRD become the marking's public earliest/latest dates, so they stay visible — only *setting* them is gated. No schema/migration.

## Tests
+2 backend (`test_contribution_submit`): contributor's dates stripped / editor's preserved. Full common suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)