### PR TITLE
fix(test): align guidelines.test with shipped #23 Rate-vs-Aux copy

### DIFF
--- a/frontend/src/labels/guidelines.test.ts
+++ b/frontend/src/labels/guidelines.test.ts
@@ -30,12 +30,14 @@ describe("submission guidelines copy", () => {
     const marking = bodyFor(MARKING_SUBMISSION_GUIDELINES, "Rate vs. Auxiliary markings");
     expect(marking).toMatch(/rate mark/i);
     expect(marking).toMatch(/auxiliary/i);
-    // Ian's canonical examples (2026-06): Rate = Paid/Free/3/Due 3,
-    // Auxiliary = Advertised/Missent.
-    expect(marking).toMatch(/"Paid".*"Free"/);
-    expect(marking).toMatch(/"Due 3"/);
-    expect(marking).toMatch(/"Advertised"/);
-    expect(marking).toMatch(/"Missent"/);
+    // Shipped #23 copy uses the number heuristic: Rate examples are
+    // numerals/"PAID 3"; Auxiliary examples are word handstamps; and the
+    // "a marking bearing a number is a Rate Mark" rule of thumb is stated.
+    expect(marking).toMatch(/"3".*"5"/);
+    expect(marking).toMatch(/"PAID 3"/);
+    expect(marking).toMatch(/"FORWARDED"/);
+    expect(marking).toMatch(/"MISSENT"/);
+    expect(marking).toMatch(/bearing a number is a Rate Mark/i);
     // Cover form must NOT carry the marking-type explanation.
     expect(
       COVER_SUBMISSION_GUIDELINES.some((g) => g.label === "Rate vs. Auxiliary markings"),


### PR DESCRIPTION
**Test-only fix.** PRs #57 and #61/#23 both merged to `staging` without pre-merge CI: #57 left `guidelines.test.ts` asserting the OLD Rate-vs-Aux copy (`"Paid"`/`"Free"`/`"Due 3"`/`"Advertised"`) while #23 rewrote `guidelines.ts` to the number-heuristic copy (`"3"`/`"5"`/`"PAID 3"`/`"FORWARDED"`/`"MISSENT"`).

As a result, `npx jest src/labels/guidelines.test.ts` **fails on current `staging` HEAD**. This updates the assertions to the shipped copy (incl. the "a marking bearing a number is a Rate Mark" rule of thumb).

No application change — only the stale test assertions. Unblocks CI for any branch off `staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)