### PR TITLE
Catalog munger fixes for the MD/MI (4-state) re-run (#33/#25B/#34/#26/#32/#38/#36)

### DIFF
--- a/tools/ascc_data_munger.py
+++ b/tools/ascc_data_munger.py
@@ -148,9 +148,33 @@ def main(argv=None):
         (re.compile(r'\(backstamp\)', re.IGNORECASE),    'Backstamp'),
         (re.compile(r'\(no town cds\)', re.IGNORECASE),  'No town cds'),
     ]
+    # Capture-style desc annotations: the desc line is built from the matched
+    # text (group 1) rather than a fixed label, so per-marking specifics are
+    # preserved. Letter-position notation -- ("S"&"D"high), ("D"high) -- records
+    # which inscription letters sit high/low in the strike; capture it verbatim
+    # into desc so editors see it (Issue #33: ANNAPS.MD "S"/"D" high).
+    _DESC_CAPTURE_ANNOTATIONS = [
+        (re.compile(
+            r'\(\s*("[A-Za-z]"(?:\s*[&,]\s*"[A-Za-z]")*\s*(?:high|low)[^)]*?)\s*\)',
+            re.IGNORECASE),
+         lambda m: re.sub(r'\s+', ' ', m.group(1)).strip()),
+        # Named franking privilege (e.g. BARRY "Congressional frank[ms]"): a
+        # free-mail marking whose franking authority belongs in the note
+        # (Issue #34). The [ms] bracket, if any, is dropped from the label.
+        (re.compile(
+            r'\b((?:Congressional|Senatorial|Presidential|Free)\s+frank)\b',
+            re.IGNORECASE),
+         lambda m: m.group(1)),
+    ]
     def _paren_annotation_lines(text):
         s = str(text or '')
-        return [label for pat, label in _DESC_PAREN_ANNOTATIONS if pat.search(s)]
+        lines = [label for pat, label in _DESC_PAREN_ANNOTATIONS if pat.search(s)]
+        for pat, fmt in _DESC_CAPTURE_ANNOTATIONS:
+            for m in pat.finditer(s):
+                line = fmt(m)
+                if line and line not in lines:
+                    lines.append(line)
+        return lines
     df['paren_annotations_desc'] = df['clean_text'].apply(_paren_annotation_lines)
     # Keep has_backstamp as a separate column for any callers that depend on
     # the specific flag (none today, but cheaper than searching for them).
@@ -1023,8 +1047,35 @@ def main(argv=None):
     # ======================================================================
     # Step 7: Relationship Resolution
     # ======================================================================
+    # Line-wrap name repairs: a few catalog town names are split mid-word
+    # across a typeset line break, where the '/' is NOT a town/state separator
+    # (Issue #32). extract_town_root() splits on '/', so "ANNA/POLIS" would
+    # otherwise resolve to town "ANNA" and the backstamp would never file under
+    # Annapolis. Conservative explicit list -- flagged to Ian to confirm/extend;
+    # NOT a general /-repair (that would mangle real "TOWN/STATE" inscriptions).
+    _WRAPPED_NAME_REPAIRS = {
+        'ANNA/POLIS': 'ANNAPOLIS',
+    }
+    if listings['head_name_body'].isin(_WRAPPED_NAME_REPAIRS).any():
+        n_rep = int(listings['head_name_body'].isin(_WRAPPED_NAME_REPAIRS).sum())
+        listings['head_name_body'] = listings['head_name_body'].map(
+            lambda v: _WRAPPED_NAME_REPAIRS.get(v, v) if isinstance(v, str) else v)
+        print(f'Step 7 (pre): repaired {n_rep} line-wrapped town name(s)')
     listings = resolve_relationships(listings)
     listings = roll_up_catalog_text(listings)
+    # Issue #36: (E)/(L) merge. A "(L)" relationship row records a *later
+    # observed date* of its parent (E) marking, not a separate marking (Ian:
+    # Adamsville's (E) Feb-14-1834 and (L) Dec-11-1834 are ONE marking spanning
+    # that range). Flag (L) rows with a resolvable parent so the fan-out emits no
+    # duplicate townmark and dates_seen attaches their date to the parent.
+    _L_REL_RE = re.compile(r'[(\[{]\s*L\s*[)\]}]', re.IGNORECASE)
+    def _is_latest_merge(r):
+        rt = r.get('head_rel_type')
+        return (isinstance(rt, str) and bool(_L_REL_RE.search(rt))
+                and pd.notna(r.get('parent_idx')))
+    listings['is_latest_merge'] = listings.apply(_is_latest_merge, axis=1)
+    print(f"Issue #36: (L) rows merged into parent (E) marking: "
+          f"{int(listings['is_latest_merge'].sum())}")
     print(f'Step 7: Relationship resolution applied to {len(listings)} listings')
     print(f'  Independent entries: {listings["parent_idx"].isna().sum()}')
     print(f'  Resolved from parent: {listings["parent_idx"].notna().sum()}')
@@ -1441,6 +1492,8 @@ def main(argv=None):
     expanded_rows = []
     next_townmark_id = 1
     for idx, row in listings.iterrows():
+        if row.get('is_latest_merge'):
+            continue  # (L) row: no own townmark; date merges into parent (#36)
         colors = row['parsed_colors']
         is_multi_color = len(colors) > 1
 
@@ -1489,12 +1542,20 @@ def main(argv=None):
 
         is_ms = bool(src['is_manuscript'])
 
-        # Dimensions: first parsed_sizes entry (if any)
+        # Dimensions: first parsed_sizes entry that carries real geometry. An
+        # unknown-size `--` placeholder (e.g. the date slot of "(--;30;...)")
+        # parses to an empty size; skipping it keeps the real diameter from
+        # being dropped (Issue #25B). Falls back to the first entry when none
+        # qualify, so normal single-size listings are unaffected.
         width, height = None, None
         is_irreg = None if is_ms else False
         date_format = None
         if src['parsed_sizes']:
-            s = src['parsed_sizes'][0]
+            s = next((z for z in src['parsed_sizes']
+                      if z.get('size_dim1') is not None
+                      or z.get('size_shape_code')
+                      or z.get('size_dateformat')),
+                     src['parsed_sizes'][0])
             width = s.get('size_dim1')
             height = s.get('size_dim2')
             if width is not None and height is None:
@@ -2526,6 +2587,11 @@ def main(argv=None):
         tm_codes = [c for c in _tm_codes_by_lst.get(listing_idx, []) if c]
         rm_codes = [c for c in _rm_codes_by_lst.get(listing_idx, []) if c]
         ax_codes = [c for c in _ax_codes_by_lst.get(listing_idx, []) if c]
+        # Issue #36: a merged (L) row emits no townmark of its own; attach its
+        # later-observed date to the parent (E) marking's townmark code(s) so
+        # the marking spans earliest..latest.
+        if src.get('is_latest_merge'):
+            tm_codes = [c for c in _tm_codes_by_lst.get(src['parent_idx'], []) if c]
         all_codes = tm_codes + rm_codes + ax_codes
         if not all_codes:
             continue
@@ -2542,10 +2608,14 @@ def main(argv=None):
                 elif gran == 'YEAR':
                     obs = _date_cls(d['date_year_start'], 1, 1)
                     obs_rows.append((str(obs), 'YEAR'))
-                elif gran in ('RANGE', 'DECADE'):
+                elif gran == 'RANGE':
                     for yr in (d['date_year_start'], d['date_year_end']):
                         obs = _date_cls(int(yr), 1, 1)
                         obs_rows.append((str(obs), 'YEAR'))
+                # DECADE intentionally emits NO dates_seen row: a decade-level
+                # date ("1850's") is too imprecise to be a "date seen", so the
+                # marking's date field stays blank and the decade is recorded in
+                # the note instead (Issue #26; see desc assembly below).
             except (ValueError, TypeError, KeyError):
                 # Bad date components in source; Step 6 already reports parse errors.
                 continue
@@ -2667,6 +2737,11 @@ def main(argv=None):
         if _frame is not None and len(_frame) and "source_listing_idx" in _frame.columns:
             _emitted_listing_idxs.update(_frame["source_listing_idx"].dropna().astype(int).tolist())
     _expected = set(listings.index.tolist())
+    # (#36) merged (L) rows intentionally emit no marking of their own -- their
+    # later-observed date is folded into the parent (E) marking -- so they are
+    # not expected to appear in the coverage set.
+    if 'is_latest_merge' in listings.columns:
+        _expected -= set(listings.index[listings['is_latest_merge'].fillna(False)].tolist())
     _missing = sorted(_expected - _emitted_listing_idxs)
     if _missing:
         head = _missing[:20]
@@ -2776,6 +2851,15 @@ def main(argv=None):
         _see = _lrow.get('see_clause')
         if _see and isinstance(_see, str) and _see.strip():
             _lines.append(_see.strip())
+        # Decade-level dates are dropped from the date field (too imprecise to
+        # be a "date seen") and recorded here instead (Issue #26): "1850's" ->
+        # note line "Dates seen: 1850s".
+        _decades = []
+        for _d in (_lrow.get('parsed_dates') or []):
+            if _d.get('date_granularity') == 'DECADE' and _d.get('date_year_start'):
+                _decades.append(f"{int(_d['date_year_start'])}s")
+        if _decades:
+            _lines.append("Dates seen: " + ", ".join(dict.fromkeys(_decades)))
         if _lines:
             desc_by_listing[_lidx] = "\n".join(_lines)
     marking_rows = []

--- a/tools/munger/assembly.py
+++ b/tools/munger/assembly.py
@@ -51,6 +51,16 @@ def resolve_effective_shape(row):
         if s.get('size_shape_code'):
             return s['size_shape_code'].upper(), 'paren_body'
 
+    # 1b. Bare diameter -> circle. A single measured dimension with no shape
+    # code and no second dimension is a circular datestamp diameter: the catalog
+    # writes "27" (not "SL-27") for a round mark, and reserves "WxH" for straight
+    # lines/ovals. Stronger evidence than a section default, so it precedes it
+    # (Issue #38: ADA.MI "(1837-45;27;Red)" was defaulting to SL).
+    for s in row['parsed_sizes']:
+        if (s.get('size_dim1') is not None and s.get('size_dim2') is None
+                and not s.get('size_shape_code')):
+            return 'C', 'bare_diameter'
+
     # 2. Section-level Default Shape
     default = row.get('Default Shape')
     if pd.notna(default) and str(default).strip():

--- a/tools/munger/fields/__init__.py
+++ b/tools/munger/fields/__init__.py
@@ -39,6 +39,11 @@ def is_color_field(field):
 
 BARE_NUMBER_RE = re.compile(r'^\d{1,3}(?:\.\d+)?$')
 
+# Smallest plausible circular-datestamp diameter (mm). A bare number below this
+# in the size slot of an unknown-date listing is a rate (e.g. a 2c drop rate),
+# not a sub-centimetre circle. Town CDS diameters in ASCC run ~15-60mm.
+MIN_BARE_DIAMETER_MM = 13.0
+
 def classify_paren_field(field_text):
     """Classify a single paren field by intrinsic content signals.
     Returns one of: date, ms, size, rate, color, other, empty."""
@@ -80,12 +85,34 @@ def classify_all_fields(paren_fields):
     # If a second 'size' appears and it's a bare number (no shape code, no
     # dateformat, no dimension separator), reclassify it as 'rate'.
     size_seen = False
+    saw_dash = False
     for i, (field, ftype) in enumerate(zip(paren_fields, types)):
-        if ftype == 'size':
-            if size_seen and BARE_NUMBER_RE.match(field.strip()):
+        if ftype != 'size':
+            continue
+        fstrip = field.strip()
+        # A bare-dash placeholder (`-`, `--`) is an *unknown* size, not a real
+        # measurement, so it must not consume the single size slot.
+        if fstrip in ('-', '--'):
+            saw_dash = True
+            continue
+        is_bare = bool(BARE_NUMBER_RE.match(fstrip))
+        if is_bare and saw_dash and not size_seen:
+            # First real number after an unknown-size `--` placeholder. It keeps
+            # the size slot when it's a plausible diameter (Issue #25B, Amelia
+            # "(--;28;...)" -> circle size 28, previously mis-read as a rate),
+            # but a rate-magnitude value stays a rate (PONTIAC
+            # "Same(--;2;Red) Drop rate" -> 2c drop rate, not a 2mm circle).
+            if float(fstrip) < MIN_BARE_DIAMETER_MM:
                 types[i] = 'rate'
             else:
                 size_seen = True
+            continue
+        # Legacy positional rule (unchanged for non-dash listings): the first
+        # size fills the slot; a later bare number is a rate.
+        if size_seen and is_bare:
+            types[i] = 'rate'
+        else:
+            size_seen = True
 
     return types
 
@@ -170,6 +197,25 @@ def triage_other_field(text):
 
     return 'other', None
 
+def _any_manuscript_rate(parsed_rates):
+    """True if any parsed rate token carries the [ms] manuscript bracket."""
+    for group in parsed_rates:
+        tokens = group if isinstance(group, list) else [group]
+        for t in tokens:
+            if isinstance(t, dict) and t.get('rate_is_manuscript'):
+                return True
+    return False
+
+
+def _has_real_size_device(parsed_sizes):
+    """True if any parsed size is a real struck device (a dimension or an
+    explicit shape code), not just an unknown `--` placeholder."""
+    return any(
+        s.get('size_dim1') is not None or s.get('size_shape_code')
+        for s in parsed_sizes
+    )
+
+
 def subparse_fields(row):
     """Apply the appropriate sub-parser to each paren field based on its type.
     Returns parallel lists: parsed_dates, parsed_sizes, parsed_rates, parsed_colors,
@@ -221,6 +267,16 @@ def subparse_fields(row):
                     parsed_colors.extend(parsed)
             else:
                 other_fields.append(field)
+
+    # A manuscript-bracketed annotation ([ms]) with no real handstamp device
+    # (no dimensioned size, no shape code) means the marking itself is
+    # manuscript -- BARRY "(c.1861-63;--;Congressional frank[ms];Black)" is a
+    # handwritten congressional frank, not a struck townmark. A [ms] alongside a
+    # real device (HICKORY CORNERS "...;C-35,NOR;Pd. 3[ms];...") is only a
+    # manuscript *rate* under a struck CDS, so it must NOT promote (Issue #34).
+    if not is_manuscript and _any_manuscript_rate(parsed_rates) \
+            and not _has_real_size_device(parsed_sizes):
+        is_manuscript = True
 
     # Union the optional CSV `Manuscript` column (if present + truthy).
     if _csv_manuscript_truthy(row):

--- a/tools/tests/test_munger_field_classify.py
+++ b/tools/tests/test_munger_field_classify.py
@@ -1,0 +1,53 @@
+"""Tests for paren-field classification disambiguation (munger.fields).
+
+Issue #25B: an unknown-size placeholder ("--") in the size position must not
+consume the single size slot, or a following bare-number diameter is wrongly
+reclassified as a fabricated rate (Amelia: "(--;28;...)" -> 28 read as a rate).
+
+Run from repo root:
+    PYTHONPATH=tools .venv/bin/python -m unittest discover -s tools/tests \
+        -p 'test_munger_field_classify.py'
+"""
+import sys
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+from munger.fields import classify_all_fields
+
+
+class DashDoesNotConsumeSizeSlot(unittest.TestCase):
+    def test_dash_then_diameter_stays_size(self):
+        # The Amelia case: unknown year placeholder, then the real circle size.
+        self.assertEqual(classify_all_fields(['--', '28']), ['size', 'size'])
+
+    def test_dash_then_diameter_then_rate(self):
+        # After the dash is skipped, 28 is the first real size and 5 is a rate.
+        self.assertEqual(
+            classify_all_fields(['--', '28', '5']), ['size', 'size', 'rate'])
+
+    def test_single_dash_placeholder(self):
+        self.assertEqual(classify_all_fields(['-', '28']), ['size', 'size'])
+
+    def test_dash_then_decimal_diameter(self):
+        self.assertEqual(classify_all_fields(['--', '32.5']), ['size', 'size'])
+
+    def test_dash_then_rate_magnitude_is_rate(self):
+        # PONTIAC "Same(--;2;Red) Drop rate": 2 is a drop rate, not a 2mm circle.
+        self.assertEqual(classify_all_fields(['--', '2']), ['size', 'rate'])
+
+
+class ExistingBehaviorPreserved(unittest.TestCase):
+    def test_second_bare_number_is_rate(self):
+        # Regression: a genuine second bare number (no dash) is still a rate.
+        self.assertEqual(classify_all_fields(['28', '5']), ['size', 'rate'])
+
+    def test_lone_diameter_is_size(self):
+        self.assertEqual(classify_all_fields(['27']), ['size'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/tests/test_munger_shape.py
+++ b/tools/tests/test_munger_shape.py
@@ -1,0 +1,67 @@
+"""Tests for shape resolution (munger.assembly.resolve_effective_shape).
+
+Issue #38: a bare single diameter ("27", no shape code, no second dimension)
+is a circular datestamp and must resolve to Circle, not the SL catalog
+fallback (ADA.MI "(1837-45;27;Red)" was defaulting to SL).
+
+Run from repo root:
+    PYTHONPATH=tools .venv/bin/python -m unittest discover -s tools/tests \
+        -p 'test_munger_shape.py'
+"""
+import sys
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+from munger.assembly import resolve_effective_shape
+
+
+def _size(dim1=None, dim2=None, shape=None):
+    return {'size_dim1': dim1, 'size_dim2': dim2, 'size_shape_code': shape}
+
+
+def _row(sizes, default=None, ms_section=False):
+    return {'parsed_sizes': sizes, 'Default Shape': default,
+            'is_manuscript_section': ms_section}
+
+
+class BareDiameterIsCircle(unittest.TestCase):
+    def test_bare_diameter(self):
+        code, src = resolve_effective_shape(_row([_size(dim1=27)]))
+        self.assertEqual(code, 'C')
+        self.assertEqual(src, 'bare_diameter')
+
+    def test_bare_diameter_with_dash_placeholder(self):
+        # "(--;27;...)": the empty placeholder is ignored, 27 -> circle.
+        code, _ = resolve_effective_shape(_row([_size(), _size(dim1=27)]))
+        self.assertEqual(code, 'C')
+
+
+class NonBareUnaffected(unittest.TestCase):
+    def test_wxh_falls_back_to_sl(self):
+        # A two-dimension mark is not a circle; no default -> SL fallback.
+        code, src = resolve_effective_shape(_row([_size(dim1=20, dim2=11)]))
+        self.assertEqual(code, 'SL')
+        self.assertEqual(src, 'catalog_fallback')
+
+    def test_explicit_shape_code_wins(self):
+        code, src = resolve_effective_shape(_row([_size(dim1=29, shape='DC')]))
+        self.assertEqual(code, 'DC')
+        self.assertEqual(src, 'paren_body')
+
+    def test_manuscript_section_has_no_shape(self):
+        code, _ = resolve_effective_shape(_row([_size(dim1=27)], ms_section=True))
+        self.assertIsNone(code)
+
+    def test_explicit_default_shape_beats_bare_when_no_diameter(self):
+        # No bare diameter present -> section default still applies.
+        code, src = resolve_effective_shape(_row([], default='Circle'))
+        self.assertEqual(code, 'C')
+        self.assertEqual(src, 'default_shape')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Seven catalog-accuracy fixes to the ASCC munger, from Ian's 2026-06-22 review of the dev site. Each fix is a targeted, conservative change to the parsing/assembly pipeline; together they correct how the MD/MI (and, because several rules are general, FL/DE) catalogs import. **No schema change / no migration.**

## Fixes

| # | Issue | Change |
|---|-------|--------|
| #33 | Annaps "S"/"D" high | Capture letter-position notations (`("S"&"D"high)`, `("D"high)`) verbatim into the marking `desc`. Generalized catalog-wide (86 MD markings). |
| #25B | Amelia: circle size read as rate | An unknown-size `--` placeholder no longer consumes the size slot. Magnitude rule (`MIN_BARE_DIAMETER_MM = 13`): a bare number after `--` is a circle diameter if ≥13mm, else a rate — so PONTIAC's real 2¢ *drop rate* survives. Also fixed the dimension-pick so the diameter lands on the townmark instead of vanishing. |
| #34 | Barry/Md congressional frank | A `[ms]` bracket with **no struck device** (no dim, no shape code) promotes the marking to manuscript; a `[ms]` rate under a real CDS (HICKORY CORNERS `C-35`) does not. "Congressional frank" → `desc`. |
| #26 | Decade dates | A decade-level date (`1850's`) leaves the date field blank and is recorded as a `Dates seen: 1850s` note (real dates alongside a decade are preserved). |
| #32 | Anna/Polis | Targeted `ANNA/POLIS → ANNAPOLIS` line-wrap alias (not a general `/`-repair, which would mangle real `TOWN/STATE` inscriptions). The backstamp now files under Annapolis; the spurious "ANNA" PO is gone. |
| #38 | ADA.MI shape | A bare single diameter (no shape code) resolves to **Circle**, ahead of the SL catalog fallback (the catalog writes `27`, not `SL-27`). 441 MI flips; MD already circle-defaulted. |
| #36 | Adamsville (E)/(L) | An `(E)`/`(L)` sibling pair collapses into **one** marking spanning earliest..latest (Adamsville → one townmark, 1834-02-14..1834-12-11). 172 MI + 12 MD + 144 FL `(L)` rows merged. |

## Tests

`tools/tests/test_munger_field_classify.py` + `tools/tests/test_munger_shape.py` added; full munger suite **34/34 green** (`PYTHONPATH=tools python -m unittest discover -s tools/tests -p 'test_munger_*.py'`).

## Verification (4 states)

Each fix was verified by re-munge + an ID-agnostic semantic diff (content-matched, not by sequential IDs). Across MI/FL/MD/DE every changed marking is attributable to a specific fix, **ADDED ≈ 0** (no spurious markings):

| State | markings | note |
|---|---|---|
| MI | 2617 → 2384 | (E)/(L) merges + phantom rates; 441 → Circle |
| FL | 946 → 784 | (E)/(L) merges + phantom rates |
| MD | 1718 → 1703 | merges + phantom + ANNA→ANNAPOLIS + S/D notes |
| DE | 295 → 291 | phantom rates |

**Merged census 5,576 → 5,162.** The −414 is the intended dedup (merging duplicate (E)/(L) listings + removing phantom rates). Merged bundle FK-validated; `import_ascc_bundle --dry-run` reported **`error=0` across all tables**.

Verified live on **woco.dev** (dev/demo box) via a data-only re-import. **Prod (hellowoco.app) is not affected by this code PR** — the data load there is a separate, gated step.

## Notes for review

- **No migration** — pure parsing/assembly logic; deployable as-is.
- The census drop (−414) is expected and correct; it reflects catalog dedup, not data loss.
- `#32` ships one explicit `ANNA/POLIS` alias; the `ANNAPOLIS`/`ANNAPOLIS MD`/`ANNAPS.MD` spelling variants remain distinct (a separate town-alias question for the editors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)