### PR TITLE
ci: use WOCO_DEV_SSH_KEY for woco.dev deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -98,7 +98,7 @@ jobs:
           # must be set to prohibit-password in sshd_config (see
           # docs/devel/STAGING_WOCO_DEV.md for the 2026-06-22 recovery note).
           username: root
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          key: ${{ secrets.WOCO_DEV_SSH_KEY }}
           command_timeout: 20m
           script: |
             set -euo pipefail


### PR DESCRIPTION
One-line fix: swap DEPLOY_SSH_KEY → WOCO_DEV_SSH_KEY in the woco.dev deploy step. DEPLOY_SSH_KEY is authorized on hellowoco.app (wocod) but not on woco.dev (root). Reese has added WOCO_DEV_SSH_KEY to repo secrets.