### PR TITLE
ci: deploy to woco.dev as reese user with dedicated WOCO_DEV_SSH_KEY

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -98,7 +98,7 @@ jobs:
           # must be set to prohibit-password in sshd_config (see
           # docs/devel/STAGING_WOCO_DEV.md for the 2026-06-22 recovery note).
           username: root
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          key: ${{ secrets.WOCO_DEV_SSH_KEY }}
           command_timeout: 20m
           script: |
             set -euo pipefail

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -85,25 +85,21 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy to woco.dev (SSH as root)
+      - name: Deploy to woco.dev (SSH as reese)
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: woco.dev
-          # SSH as root on woco.dev (Reese's staging box). Root has no
-          # narrow sudoers restriction here — it owns the box outright.
-          # uv is installed under the wocod service account, so deploy.sh
-          # is invoked via `sudo -u wocod` to keep the uv PATH correct.
-          # PREREQUISITE: DEPLOY_SSH_KEY public key must be in
-          # /root/.ssh/authorized_keys on woco.dev and PermitRootLogin
-          # must be set to prohibit-password in sshd_config (see
-          # docs/devel/STAGING_WOCO_DEV.md for the 2026-06-22 recovery note).
-          username: root
+          # SSH as `reese` (sudo group, NOPASSWD) — never as root.
+          # PREREQUISITE: woco.dev must have a `reese` user whose
+          # authorized_keys holds the WOCO_DEV_SSH_KEY public key.
+          # WOCO_DEV_SSH_KEY must be a dedicated deploy key, not a personal key.
+          username: reese
           key: ${{ secrets.WOCO_DEV_SSH_KEY }}
           command_timeout: 20m
           script: |
             set -euo pipefail
             # Stop the app so migrations can run without table locks.
-            systemctl stop worldcovers
+            sudo systemctl stop worldcovers
             # Pull the latest staging tip.
             git -C /srv/woco fetch origin
             git -C /srv/woco reset --hard origin/staging
@@ -113,10 +109,10 @@ jobs:
             # Re-install the systemd unit file only when it has changed.
             if ! diff -q /srv/woco/tools/worldcovers.service /etc/systemd/system/worldcovers.service > /dev/null 2>&1; then
                 echo "Updating systemd unit file..."
-                install -m 644 /srv/woco/tools/worldcovers.service /etc/systemd/system/worldcovers.service
-                systemctl daemon-reload
+                sudo install -m 644 /srv/woco/tools/worldcovers.service /etc/systemd/system/worldcovers.service
+                sudo systemctl daemon-reload
             fi
-            # Re-own after root's git ops; uv lives in wocod's ~/.local/bin.
-            chown -R wocod:wocod /srv/woco
+            # Re-own so wocod can run deploy.sh; uv lives in wocod's ~/.local/bin.
+            sudo chown -R wocod:wocod /srv/woco
             sudo -u wocod -H bash -lc 'export PATH=$HOME/.local/bin:$PATH && cd /srv/woco && ./tools/deploy.sh'
-            systemctl start worldcovers
+            sudo systemctl start worldcovers


### PR DESCRIPTION
## Summary
- Routes staging CI deploys to woco.dev as `reese` (sudo group) instead of `root` — automated root logins violate security best practice; a healthy box has no root sessions
- Separates the woco.dev deploy secret (`WOCO_DEV_SSH_KEY`) from the prod deploy secret (`DEPLOY_SSH_KEY`) so compromising one doesn't affect the other
- Adds `sudo` prefixes to `systemctl`, `chown`, and `install` calls that previously ran as root directly

## Prerequisites (all done)
- [x] `reese` user exists on woco.dev with key in `authorized_keys` and `NOPASSWD` sudo
- [x] Root SSH disabled on woco.dev (`PermitRootLogin no`)
- [x] `WOCO_DEV_SSH_KEY` GitHub secret set to dedicated deploy key (not personal key)

## Test plan
- [ ] Push any commit to `staging` and confirm CI deploys successfully to woco.dev
- [ ] Confirm `ssh root@172.238.189.147` is denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)