### PR TITLE
push_data.sh: no hardcoded deploy user — WOCO_DEPLOY_USER from .env; refuse --import with --dry-run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ PIPELINE_LLM_PROVIDER=openrouter
 PIPELINE_LLM_MODEL=
 OPENROUTER_API_KEY=
 ANTHROPIC_API_KEY=
+
+# Your personal SSH username on the woco boxes. tools/push_data.sh builds its
+# target as <user>@hellowoco.app from this; files on the server are still
+# owned/run by the wocod service account regardless of who pushes.
+WOCO_DEPLOY_USER=

--- a/tools/push_data.sh
+++ b/tools/push_data.sh
@@ -50,7 +50,9 @@ fi
 # WOCO_DEPLOY_USER from .env. The .env is extracted with sed, not sourced —
 # it is a Django-style env file whose unquoted values would break bash.
 if [[ -z "${WOCO_DEPLOY_USER:-}" && -f .env ]]; then
-  WOCO_DEPLOY_USER="$(sed -n 's/^WOCO_DEPLOY_USER=//p' .env | tail -1)"
+  # Strip any trailing inline comment and whitespace so "alice  # ssh user"
+  # yields "alice" instead of a silently broken SSH target.
+  WOCO_DEPLOY_USER="$(sed -n 's/^WOCO_DEPLOY_USER=\([^#]*\).*/\1/p' .env | tail -1 | tr -d '[:space:]')"
 fi
 if [[ -z "${WOCO_HOST:-}" ]]; then
   if [[ -z "${WOCO_DEPLOY_USER:-}" ]]; then

--- a/tools/push_data.sh
+++ b/tools/push_data.sh
@@ -10,9 +10,9 @@
 # override the full target. Files on the server are always owned by wocod
 # regardless of who pushes.
 #
-# Prereq on the server: your SSH user can run `sudo` without a password —
-# blanket passwordless sudo is fine. For a host without blanket sudo, a
-# minimal drop-in would be (replace <user> with your SSH user):
+# Prereq on the server: your SSH user needs passwordless sudo for exactly the
+# two commands below. Use a scoped drop-in (replace <user> with your SSH user)
+# rather than blanket NOPASSWD — blanket sudo makes the SSH key root-equivalent:
 #   # /etc/sudoers.d/<user>-rsync
 #   <user> ALL=(root) NOPASSWD: /usr/bin/rsync
 #   <user> ALL=(wocod) NOPASSWD: /srv/woco/tools/reload_data.sh
@@ -21,21 +21,30 @@
 #   ./tools/push_data.sh              # push only
 #   ./tools/push_data.sh --import     # push, then run imports as wocod
 #   ./tools/push_data.sh --dry-run    # show what rsync would do
+#                                     # (refuses --import: the import is never a dry run)
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 DO_IMPORT=0
+DRY_RUN=0
 RSYNC_EXTRA=()
 for arg in "$@"; do
   case "$arg" in
     --import)  DO_IMPORT=1 ;;
-    --dry-run) RSYNC_EXTRA+=("--dry-run") ;;
+    --dry-run) DRY_RUN=1; RSYNC_EXTRA+=("--dry-run") ;;
     -h|--help)
-      sed -n '2,23p' "$0"; exit 0 ;;
+      sed -n '2,24p' "$0"; exit 0 ;;
     *) echo "Unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
+
+# --dry-run only previews the rsyncs; there is no dry-run for the import,
+# which truncate-reloads the live DB. Refuse the combination outright.
+if [[ $DRY_RUN -eq 1 && $DO_IMPORT -eq 1 ]]; then
+  echo "push_data.sh: refusing --import with --dry-run — the import step is never a dry run." >&2
+  exit 2
+fi
 
 # Resolve the SSH target. Precedence: WOCO_HOST env > WOCO_DEPLOY_USER env >
 # WOCO_DEPLOY_USER from .env. The .env is extracted with sed, not sourced —

--- a/tools/push_data.sh
+++ b/tools/push_data.sh
@@ -5,12 +5,17 @@
 # the app runtime can read them without a manual chown dance. With --import,
 # also triggers /srv/woco/tools/reload_data.sh as the wocod user.
 #
-# Prereq on the server: the SSH user (default: mpc) can run `sudo` without a
-# password — blanket passwordless sudo is fine. For a host without blanket
-# sudo, a minimal drop-in would be:
-#   # /etc/sudoers.d/mpc-rsync
-#   mpc ALL=(root) NOPASSWD: /usr/bin/rsync
-#   mpc ALL=(wocod) NOPASSWD: /srv/woco/tools/reload_data.sh
+# No username is baked into this script. Set WOCO_DEPLOY_USER in the repo-root
+# .env (gitignored; see .env.example), or export WOCO_HOST=user@host to
+# override the full target. Files on the server are always owned by wocod
+# regardless of who pushes.
+#
+# Prereq on the server: your SSH user can run `sudo` without a password —
+# blanket passwordless sudo is fine. For a host without blanket sudo, a
+# minimal drop-in would be (replace <user> with your SSH user):
+#   # /etc/sudoers.d/<user>-rsync
+#   <user> ALL=(root) NOPASSWD: /usr/bin/rsync
+#   <user> ALL=(wocod) NOPASSWD: /srv/woco/tools/reload_data.sh
 #
 # Usage:
 #   ./tools/push_data.sh              # push only
@@ -20,9 +25,6 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-HOST="${WOCO_HOST:-mpc@hellowoco.app}"
-REMOTE_ROOT="${WOCO_REMOTE_ROOT:-/srv/woco}"
-
 DO_IMPORT=0
 RSYNC_EXTRA=()
 for arg in "$@"; do
@@ -30,10 +32,28 @@ for arg in "$@"; do
     --import)  DO_IMPORT=1 ;;
     --dry-run) RSYNC_EXTRA+=("--dry-run") ;;
     -h|--help)
-      sed -n '2,22p' "$0"; exit 0 ;;
+      sed -n '2,23p' "$0"; exit 0 ;;
     *) echo "Unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
+
+# Resolve the SSH target. Precedence: WOCO_HOST env > WOCO_DEPLOY_USER env >
+# WOCO_DEPLOY_USER from .env. The .env is extracted with sed, not sourced —
+# it is a Django-style env file whose unquoted values would break bash.
+if [[ -z "${WOCO_DEPLOY_USER:-}" && -f .env ]]; then
+  WOCO_DEPLOY_USER="$(sed -n 's/^WOCO_DEPLOY_USER=//p' .env | tail -1)"
+fi
+if [[ -z "${WOCO_HOST:-}" ]]; then
+  if [[ -z "${WOCO_DEPLOY_USER:-}" ]]; then
+    echo "push_data.sh: no deploy user configured." >&2
+    echo "Set WOCO_DEPLOY_USER=<your-ssh-user> in .env (see .env.example)," >&2
+    echo "or export WOCO_HOST=user@host to override the full target." >&2
+    exit 2
+  fi
+  WOCO_HOST="${WOCO_DEPLOY_USER}@hellowoco.app"
+fi
+HOST="$WOCO_HOST"
+REMOTE_ROOT="${WOCO_REMOTE_ROOT:-/srv/woco}"
 
 # -a           preserve timestamps/symlinks
 # --delete     mirror source (removes server-side files missing locally)

--- a/tools/tests/test_push_data.py
+++ b/tools/tests/test_push_data.py
@@ -66,13 +66,13 @@ class PushDataHostResolution(unittest.TestCase):
     def test_help_works_without_any_config(self):
         result = self.run_script("--help")
         self.assertEqual(result.returncode, 0)
-        self.assertIn("push_data.sh", result.stdout)
+        self.assertIn("--dry-run", result.stdout)
 
     def test_env_file_user_builds_host(self):
         (self.tmp / ".env").write_text(
             "DEBUG=True\n"
             "DEFAULT_FROM_EMAIL=WorldCovers <no-reply@hellowoco.app>\n"
-            "WOCO_DEPLOY_USER=alice\n"
+            "WOCO_DEPLOY_USER=alice  # my ssh user\n"
         )
         result = self.run_script()
         self.assertEqual(result.returncode, 0, result.stderr)

--- a/tools/tests/test_push_data.py
+++ b/tools/tests/test_push_data.py
@@ -1,0 +1,91 @@
+"""Regression tests for tools/push_data.sh host resolution.
+
+Run from repo root:
+    PYTHONPATH=tools .venv/bin/python -m unittest discover \
+        -s tools/tests -p 'test_push_data.py'
+
+Expected exit code: 0.
+
+The script is copied into a temp repo root so the tests never read the
+developer's real .env or touch the network: rsync is stubbed out on PATH
+and just records the arguments it was called with.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "push_data.sh"
+
+RSYNC_STUB = """#!/usr/bin/env bash
+printf '%s\\n' "$@" >> "$RSYNC_LOG"
+exit 0
+"""
+
+
+class PushDataHostResolution(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        (self.tmp / "tools").mkdir()
+        (self.tmp / "tools" / "wip").mkdir()
+        (self.tmp / "backend" / "media").mkdir(parents=True)
+        self.script = self.tmp / "tools" / "push_data.sh"
+        shutil.copy(SCRIPT, self.script)
+        self.script.chmod(0o755)
+        # rsync stub that records its argv instead of talking to a server
+        bindir = self.tmp / "bin"
+        bindir.mkdir()
+        self.rsync_log = self.tmp / "rsync.log"
+        stub = bindir / "rsync"
+        stub.write_text(RSYNC_STUB)
+        stub.chmod(0o755)
+        self.env = {
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "RSYNC_LOG": str(self.rsync_log),
+            "HOME": str(self.tmp),
+        }
+
+    def run_script(self, *args, env_extra=None):
+        env = dict(self.env)
+        if env_extra:
+            env.update(env_extra)
+        return subprocess.run(
+            [str(self.script), *args],
+            env=env, capture_output=True, text=True,
+        )
+
+    def test_fails_loudly_when_no_user_configured(self):
+        result = self.run_script()
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("WOCO_DEPLOY_USER", result.stderr)
+
+    def test_help_works_without_any_config(self):
+        result = self.run_script("--help")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("push_data.sh", result.stdout)
+
+    def test_env_file_user_builds_host(self):
+        (self.tmp / ".env").write_text(
+            "DEBUG=True\n"
+            "DEFAULT_FROM_EMAIL=WorldCovers <no-reply@hellowoco.app>\n"
+            "WOCO_DEPLOY_USER=alice\n"
+        )
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("alice@hellowoco.app:", self.rsync_log.read_text())
+
+    def test_woco_host_env_overrides_env_file(self):
+        (self.tmp / ".env").write_text("WOCO_DEPLOY_USER=alice\n")
+        result = self.run_script(env_extra={"WOCO_HOST": "bob@example.org"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        log = self.rsync_log.read_text()
+        self.assertIn("bob@example.org:", log)
+        self.assertNotIn("alice@", log)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_push_data.py
+++ b/tools/tests/test_push_data.py
@@ -78,6 +78,13 @@ class PushDataHostResolution(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("alice@hellowoco.app:", self.rsync_log.read_text())
 
+    def test_dry_run_refuses_import(self):
+        (self.tmp / ".env").write_text("WOCO_DEPLOY_USER=alice\n")
+        result = self.run_script("--dry-run", "--import")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("never a dry run", result.stderr)
+        self.assertFalse(self.rsync_log.exists(), "no rsync may run")
+
     def test_woco_host_env_overrides_env_file(self):
         (self.tmp / ".env").write_text("WOCO_DEPLOY_USER=alice\n")
         result = self.run_script(env_extra={"WOCO_HOST": "bob@example.org"})


### PR DESCRIPTION
Per Michael's request: remove any specific user from push_data.sh and rely on the local .env for the username. wocod remains the owner/runtime user on both boxes — nothing changes server-side.

## Changes
- Host resolution: `WOCO_HOST` env > `WOCO_DEPLOY_USER` env > `WOCO_DEPLOY_USER` in the gitignored repo-root `.env`; fails with a clear message when none is set. No username default remains in the script.
- `.env` is **sed-extracted, not sourced** — it's a Django-style env file whose unquoted values (`DEFAULT_FROM_EMAIL=WorldCovers <no-reply@...>`) are not valid bash and would kill the script under `set -e`.
- `WOCO_DEPLOY_USER=` documented in `.env.example`.
- Safety: `--dry-run` now **refuses** `--import` — previously the rsyncs were previewed but the import still really truncate-reloaded the live DB.
- Header requires the two-command scoped sudoers drop-in instead of endorsing blanket NOPASSWD.

## Tests
`tools/tests/test_push_data.py` (new, 5 tests): missing-user failure, `--help` without config, `.env` resolution builds `user@hellowoco.app` (with a Django-style `.env` fixture), `WOCO_HOST` override precedence, and dry-run/import refusal with no rsync executed (PATH-stubbed rsync).

Note for reviewers: I read "wocod user should be who deploys on both boxes" as the ownership/runtime invariant (`--chown=wocod:wocod`, `sudo -u wocod`), which is unchanged — not as "SSH in as wocod". Please confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)