### PR TITLE
Security hardening: admin password handling, malware-gate errors, -O-safe validation, basename traversal

### DIFF
--- a/tools/ascc_image_extract.py
+++ b/tools/ascc_image_extract.py
@@ -169,6 +169,10 @@ class Paths:
     """Per-run filesystem layout, derived from the basename."""
 
     def __init__(self, basename, input_csv=None):
+        # basename becomes a path component under tools/wip/; reject anything
+        # that could escape it (e.g. "../../x").
+        if not basename or "/" in basename or "\\" in basename or ".." in basename:
+            raise ValueError(f"invalid basename {basename!r}: must be a bare name")
         self.basename       = basename
         self.images_dir     = WIP_DIR / "cache" / f"{basename}_chunks"
         self.input_csv      = Path(input_csv) if input_csv else WIP_DIR / "cache" / f"{basename}.csv"

--- a/tools/ascc_page_extract.py
+++ b/tools/ascc_page_extract.py
@@ -240,6 +240,10 @@ If a chunk is pure illustration with no catalog text below, return
 class Paths:
     """Per-run filesystem layout, derived from the basename."""
     def __init__(self, basename, output_csv=None):
+        # basename becomes a path component under tools/wip/; reject anything
+        # that could escape it (e.g. "../../x").
+        if not basename or "/" in basename or "\\" in basename or ".." in basename:
+            raise ValueError(f"invalid basename {basename!r}: must be a bare name")
         self.basename   = basename
         self.images_dir = WIP_DIR / "cache" / f"{basename}_chunks"
         self.output_csv = Path(output_csv) if output_csv else WIP_DIR / "cache" / f"{basename}.csv"
@@ -508,17 +512,23 @@ def extract_chunk(llm, model, image_path, page, chunk_seq):
                 f"model returned non-JSON after 2 attempts; raw={snippet!r}"
             )
 
-    assert isinstance(parsed, dict), f"top-level not dict: {type(parsed)}"
+    # LLM output is untrusted: validate with explicit raises, not assert,
+    # so the checks survive `python -O`.
+    if not isinstance(parsed, dict):
+        raise ValueError(f"top-level not dict: {type(parsed)}")
     images_above = parsed.get("images_above")
-    assert isinstance(images_above, int) and images_above >= 0, \
-        f"images_above bad: {images_above!r}"
+    if not (isinstance(images_above, int) and images_above >= 0):
+        raise ValueError(f"images_above bad: {images_above!r}")
     entries = parsed.get("entries")
-    assert isinstance(entries, list), f"entries not list: {type(entries)}"
+    if not isinstance(entries, list):
+        raise ValueError(f"entries not list: {type(entries)}")
     for i, r in enumerate(entries):
-        assert isinstance(r, dict), f"entry[{i}] not dict"
-        assert isinstance(r.get("text"), str), f"entry[{i}].text not str"
-        assert r.get("type") in ("LISTING", "META"), \
-            f"entry[{i}].type bad: {r.get('type')!r}"
+        if not isinstance(r, dict):
+            raise ValueError(f"entry[{i}] not dict")
+        if not isinstance(r.get("text"), str):
+            raise ValueError(f"entry[{i}].text not str")
+        if r.get("type") not in ("LISTING", "META"):
+            raise ValueError(f"entry[{i}].type bad: {r.get('type')!r}")
         r["text"] = _compress_leaders(r["text"])
     return {"images_above": images_above, "entries": entries}
 

--- a/tools/ascc_page_processor.py
+++ b/tools/ascc_page_processor.py
@@ -356,6 +356,10 @@ def save_cache(path, cache):
 class Paths:
     """Per-run filesystem layout, derived from --basename."""
     def __init__(self, basename):
+        # basename becomes a path component under tools/wip/; reject anything
+        # that could escape it (e.g. "../../x").
+        if not basename or "/" in basename or "\\" in basename or ".." in basename:
+            raise ValueError(f"invalid basename {basename!r}: must be a bare name")
         self.basename     = basename
         self.pdf          = WIP_DIR / "in" / f"{basename}.pdf"
         self.full_dir     = WIP_DIR / "cache" / f"{basename}_full"
@@ -511,7 +515,8 @@ def detect_page_number(strip_im, llm, model):
     )
     data = _parse_strict_json(raw)
     pn = data["page_number"]
-    assert isinstance(pn, int) and pn >= 1, f"bad page_number {pn!r}"
+    if not (isinstance(pn, int) and pn >= 1):
+        raise ValueError(f"bad page_number {pn!r}")
     return pn
 
 
@@ -529,7 +534,8 @@ def confirm_single_column(im, llm, model):
     )
     data = _parse_strict_json(raw)
     htc = data["has_two_columns"]
-    assert isinstance(htc, bool), f"bad has_two_columns {htc!r}"
+    if not isinstance(htc, bool):
+        raise ValueError(f"bad has_two_columns {htc!r}")
     return htc
 
 
@@ -830,8 +836,9 @@ def classify_block(block_im, block_classify_cache, llm, model, verbose=False, la
     try:
         data = _parse_strict_json(raw)
         kind = data["kind"]
-        assert kind in ("illustration", "text"), f"bad kind {kind!r}"
-    except (json.JSONDecodeError, KeyError, AssertionError) as e:
+        if kind not in ("illustration", "text"):
+            raise ValueError(f"bad kind {kind!r}")
+    except (json.JSONDecodeError, KeyError, ValueError) as e:
         # Fallback: word-search on the raw text. The original notebook took
         # this path always; we use it only when JSON parse fails so a single
         # malformed response does not abort the whole run.
@@ -1093,7 +1100,8 @@ def review_slice(slice_im, chunk_cuts_cache, llm, model, verbose=False, label=""
     try:
         data = _parse_strict_json(raw)
         cuts = data["cuts"]
-        assert isinstance(cuts, list), f"cuts not a list: {cuts!r}"
+        if not isinstance(cuts, list):
+            raise ValueError(f"cuts not a list: {cuts!r}")
         # Validate and sanitize: ints, in (0, h), strictly ascending.
         clean = []
         for c in cuts:

--- a/tools/fingerprint.sh
+++ b/tools/fingerprint.sh
@@ -40,9 +40,17 @@ ROOT="${1:-.}"
 
 found=0
 for pat in "${PATTERNS[@]}"; do
-    # grep returns 1 when no match; that is the normal case. Capture matches
-    # explicitly so the script does not abort under `set -e`.
-    if matches=$(grep -rnE "$pat" "${EXCLUDES[@]}" "$ROOT" 2>/dev/null); then
+    # grep exit codes: 0 = match, 1 = no match (the normal case), >=2 = the
+    # scanner itself failed (bad path, unreadable tree). A failed scan must
+    # NOT report "OK" — that is a false negative in a security gate.
+    set +e
+    matches=$(grep -rnE "$pat" "${EXCLUDES[@]}" "$ROOT")
+    status=$?
+    set -e
+    if [ "$status" -ge 2 ]; then
+        echo "ERROR: scanner failed (grep exit $status) on pattern: $pat" >&2
+        exit 2
+    elif [ "$status" -eq 0 ]; then
         echo "MALWARE FINGERPRINT MATCH for pattern: $pat"
         echo "$matches"
         echo ""

--- a/tools/pipeline_llm.py
+++ b/tools/pipeline_llm.py
@@ -89,7 +89,8 @@ def make_pipeline_llm(provider):
     """Create the configured provider client, validating required API key."""
     if provider == PROVIDER_OPENROUTER:
         key = os.environ.get("OPENROUTER_API_KEY")
-        assert key, "OPENROUTER_API_KEY not set in .env"
+        if not key:
+            raise RuntimeError("OPENROUTER_API_KEY not set in .env")
         from openai import OpenAI
         return PipelineLLM(
             provider=provider,
@@ -101,7 +102,8 @@ def make_pipeline_llm(provider):
 
     if provider == PROVIDER_ANTHROPIC:
         key = os.environ.get("ANTHROPIC_API_KEY")
-        assert key, "ANTHROPIC_API_KEY not set in .env"
+        if not key:
+            raise RuntimeError("ANTHROPIC_API_KEY not set in .env")
         from anthropic import Anthropic
         return PipelineLLM(provider=provider, client=Anthropic(api_key=key))
 

--- a/tools/rebuild_staging_db.sh
+++ b/tools/rebuild_staging_db.sh
@@ -2,8 +2,8 @@
 # Rebuild staging database: ensure DB exists, migrate, create admin, run imports.
 # Uses database "worldcovers" by default. One-time setup: run tools/setup_worldcovers_db.sql as MySQL root.
 # Run from repo root. Requires mysql.cnf in repo root (with database=worldcovers) and CSV files in backend/imports/.
-# Usage: ./tools/rebuild_staging_db.sh [--no-import]
-set -e
+# Usage: WOCO_ADMIN_PASSWORD=... ./tools/rebuild_staging_db.sh [--no-import]
+set -euo pipefail
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
 
@@ -23,10 +23,10 @@ if [[ ! -f "$MYSQL_CNF" ]]; then
   echo "Error: mysql.cnf not found at $MYSQL_CNF. Create it from mysql.cnf.example." >&2
   exit 1
 fi
-# One-time: run scripts/setup_worldcovers_db.sql as root to create DB and grant wocod
+# One-time: run tools/setup_worldcovers_db.sql as root to create DB and grant wocod
 if ! mysql --defaults-file="$MYSQL_CNF" --database="${DB_NAME}" -e "SELECT 1;" 2>/dev/null; then
   echo "Error: Cannot use database '${DB_NAME}'. Create it and grant the mysql.cnf user access, e.g.:" >&2
-  echo "  mysql -u root -p < scripts/setup_worldcovers_db.sql" >&2
+  echo "  mysql -u root -p < tools/setup_worldcovers_db.sql" >&2
   exit 1
 fi
 
@@ -34,21 +34,33 @@ export DB_NAME
 echo "[2/5] Running migrations..."
 uv run python backend/manage.py migrate --noinput
 
-echo "[3/5] Ensuring admin user (admin / admin; change password after first login)..."
-uv run python backend/manage.py shell -c "
+# The admin password comes from WOCO_ADMIN_PASSWORD and is only set when the
+# user is first created — a re-run must never reset an existing admin's
+# password (this box is internet-facing).
+echo "[3/5] Ensuring admin user..."
+if [[ -z "${WOCO_ADMIN_PASSWORD:-}" ]]; then
+  echo "Error: WOCO_ADMIN_PASSWORD is not set. Export a strong password first, e.g.:" >&2
+  echo "  WOCO_ADMIN_PASSWORD=\"\$(openssl rand -base64 18)\" ./tools/rebuild_staging_db.sh" >&2
+  echo "  (and record it — it is only applied when the admin user is first created)" >&2
+  exit 1
+fi
+WOCO_ADMIN_PASSWORD="$WOCO_ADMIN_PASSWORD" uv run python backend/manage.py shell -c "
+import os;
 from django.contrib.auth import get_user_model;
 User = get_user_model();
 u, created = User.objects.get_or_create(username='admin', defaults={'is_superuser': True, 'is_staff': True});
-u.set_password('admin');
-u.save();
-print('Admin user ready.' if not created else 'Admin user created.')
+if created:
+    u.set_password(os.environ['WOCO_ADMIN_PASSWORD']); u.save(); print('Admin user created.')
+else:
+    print('Admin user already exists; password left unchanged.')
 "
 
 echo "[4/5] Creating Site for Django..."
-uv run python backend/manage.py shell -c "
+SITE_DOMAIN="${DJANGO_APP_HOSTNAME:-hellowoco.app}" uv run python backend/manage.py shell -c "
+import os;
 from django.contrib.sites.models import Site;
 s, _ = Site.objects.get_or_create(pk=1, defaults={'domain': 'example.com', 'name': 'WorldCovers'});
-s.domain = 'hellowoco.app';
+s.domain = os.environ['SITE_DOMAIN'];
 s.name = 'WorldCovers';
 s.save();
 print('Site updated.')

--- a/tools/tests/test_pipeline_llm.py
+++ b/tools/tests/test_pipeline_llm.py
@@ -116,12 +116,12 @@ class PipelineLLMTests(unittest.TestCase):
     def test_missing_keys_raise_exact_messages(self):
         with patch.dict("os.environ", {}, clear=True):
             with self.assertRaisesRegex(
-                AssertionError,
+                RuntimeError,
                 "OPENROUTER_API_KEY not set in .env",
             ):
                 make_pipeline_llm(PROVIDER_OPENROUTER)
             with self.assertRaisesRegex(
-                AssertionError,
+                RuntimeError,
                 "ANTHROPIC_API_KEY not set in .env",
             ):
                 make_pipeline_llm(PROVIDER_ANTHROPIC)


### PR DESCRIPTION
Fixes from a security review of the tools/ scripts (2026-07-02).

## Changes
- **`rebuild_staging_db.sh`** — the admin password previously reset to `admin`/`admin` **unconditionally on every run** on an internet-facing box. Now: password comes from `WOCO_ADMIN_PASSWORD` (script refuses to run without it) and is applied **only when the admin user is first created**; an existing admin's password is never touched. Also: Site domain honors `DJANGO_APP_HOSTNAME`, setup-SQL path corrected `scripts/` → `tools/`, `set -euo pipefail`.
- **`fingerprint.sh`** — grep exit ≥2 (scanner itself failed: bad path, unreadable tree) was swallowed by `2>/dev/null` and reported as "OK: no malware fingerprints" — a false negative in a security gate. Now exits 2 loudly. The documented exit code 2 is now reachable.
- **Pipeline `assert` → explicit raises** (`pipeline_llm.py`, `ascc_page_extract.py`, `ascc_page_processor.py`) — API-key presence and LLM-output validation were enforced only by `assert`, which `python -O` strips entirely. Converted to `RuntimeError`/`ValueError`; the two fallback handlers that caught `AssertionError` now catch `ValueError`, so recovery behavior is unchanged. `test_pipeline_llm.py` updated to expect `RuntimeError`.
- **`--basename` path traversal** — `Paths.__init__` in all three stage scripts now rejects basenames containing `/`, `\`, or `..` (a value like `../../x` could write/delete outside `tools/wip/` when the stage scripts are invoked directly; `ascc_cli.py` validates state codes but the scripts are also runnable standalone).

## Not touched (flagging, not fixing here)
- `ascc_data_munger.py`'s ~117 inline self-test asserts (same `-O` concern, but moving them to the test suite is a refactor).
- Pre-existing on staging: 4 `test_ascc_cli.py` failures from the ASCC2 → ASCC6 default change (tests still expect ASCC2).

## Tests
Full tools suite: 159 ran; only those 4 pre-existing `test_ascc_cli.py` failures remain (present on `staging` before this branch). `fingerprint.sh` exercised on both the clean and scanner-error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)