### PR TITLE
docs: align deploy/auth runbooks with the wocod-CI + personal-user model (supersedes #77/#78)

### DIFF
--- a/docs/devel/AUTH_SYNC.md
+++ b/docs/devel/AUTH_SYNC.md
@@ -36,8 +36,9 @@ directory of CSVs if you prefer to inspect them.)
 
 ```bash
 # Pull prod -> local, then push local -> woco.dev (never store it long-term):
+# Root login is disabled on the box — connect as your own user (sudo group).
 scp <prod>:/tmp/woco-auth.json ./woco-auth.json
-scp ./woco-auth.json root@172.238.189.147:/tmp/woco-auth.json
+scp ./woco-auth.json <your-user>@172.238.189.147:/tmp/woco-auth.json
 ```
 
 ## Target side — restore on `woco.dev`

--- a/docs/devel/STAGING_WOCO_DEV.md
+++ b/docs/devel/STAGING_WOCO_DEV.md
@@ -40,7 +40,9 @@ linode-cli linodes list   # note the IPv4
 ### 2. Clone the repo and provision
 
 SSH in as root, clone the repo to `/srv/woco` (provide your own git auth --
-deploy key or token), then run the provisioning script:
+deploy key or token), then run the provisioning script. Root SSH is for this
+initial provisioning ONLY — afterwards set `PermitRootLogin no` and use your
+own sudo-group user (see `DEPLOY.md` §sshd hardening):
 
 ```sh
 ssh root@<IP>
@@ -86,8 +88,10 @@ checkout:
 ./woco ascc munge MI --import-check never
 
 # 2. Push the bundle + media and reload (truncate + import) on the box.
-#    push_data.sh honours WOCO_HOST / WOCO_REMOTE_ROOT.
-WOCO_HOST=root@woco.dev ./tools/push_data.sh --import
+#    push_data.sh honours WOCO_HOST / WOCO_REMOTE_ROOT. Root login is
+#    disabled after provisioning — connect as YOUR user (sudo group);
+#    files still land owned by wocod.
+WOCO_HOST=<your-user>@woco.dev ./tools/push_data.sh --import
 ```
 
 `--import` runs `reload_data.sh` on the box, which is


### PR DESCRIPTION
Consolidates what remains of PRs #77 and #78, both of which are now superseded and closed:

- **#77** defaulted `push_data.sh` to `reese@hellowoco.app`. Michael has since asked for **no specific user at all** — #79 implements that (username from the gitignored `.env`), so a personal default would be a step backwards.
- **#78** switched CI to deploy as `reese` with `WOCO_DEV_SSH_KEY`. Staging's current workflows already went further: CI SSHes **directly as `wocod`** with dedicated `STAGING_DEPLOY_SSH_KEY`/`PROD_DEPLOY_SSH_KEY` keys and narrowly scoped `sudo -n` commands — stronger than what #78 proposed, and exactly the "wocod deploys on both boxes" model.

What was still genuinely broken from their era is the **docs**: `STAGING_WOCO_DEV.md` instructed operators to push data as `root@woco.dev` and `AUTH_SYNC.md` to `scp` as `root@` — both impossible now that root login is disabled, and contrary to the deploy model. This PR:

- `STAGING_WOCO_DEV.md`: data-push example now uses `<your-user>@woco.dev` with a note that files still land owned by `wocod`; the provisioning section's root SSH is explicitly marked initial-setup-only with a pointer to the sshd-hardening steps in `DEPLOY.md`.
- `AUTH_SYNC.md`: `scp` target updated to `<your-user>@` with the same root-disabled note.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)