### PR TITLE
#46: user-safe catalog refresh — batch backup/restore wrappers

### DIFF
--- a/backend/common/management/commands/backup_user_markings.py
+++ b/backend/common/management/commands/backup_user_markings.py
@@ -1,0 +1,251 @@
+"""
+Batch-export every Marking that carries user-origin content to per-marking
+JSON backups (one backup_marking call per Marking.code).
+
+Built for the drop/re-import refresh flow: drop_ascc_state deletes a state's
+catalog tree INCLUDING the user-submitted covers, images, and contributions
+hanging off its markings, and post-policy bundles no longer contain covers.
+Running this before the drop (and restore_user_markings after the re-import)
+is what preserves that data across a refresh.
+
+A marking is considered to carry user content when any of these hold:
+  * it has at least one CoverMarking (covers are user/legacy data and are
+    never re-created by bundle import),
+  * a Contribution references it, directly or through a cover-submission
+    payload,
+  * an editor vetted it (is_reviewed=True),
+  * it has MarkingVersion edit history,
+  * --uploader USERNAME is given and a MARKING-subject Image was uploaded by
+    that user. Catalog-imported image rows are attributed via the bundle's
+    uploaded_by column, so image provenance is data-dependent; pass the
+    usernames of real people (e.g. --uploader wayne).
+
+Markings that match but have no code cannot be exported by backup_marking;
+they are reported in the manifest, never silently skipped. Covers with no
+CoverMarking at all are unreachable from any per-marking backup and are
+likewise reported.
+
+A backup failure aborts the run (fail-fast: a partial backup must not be
+mistaken for a complete one before a destructive drop). The restore side is
+the opposite: restore_user_markings continues past failures and reports them.
+
+Usage:
+    python backend/manage.py backup_user_markings ./tools/wip/user-backups
+    python backend/manage.py backup_user_markings ./tools/wip/user-backups --state VA
+    python backend/manage.py backup_user_markings ./tools/wip/user-backups --list-only
+"""
+import json
+from pathlib import Path
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+from django.utils import timezone
+
+from common.management.commands.backup_marking import _cover_contribution_marking_id
+from common.models import (
+    Contribution,
+    Cover,
+    CoverMarking,
+    Image,
+    Marking,
+    MarkingVersion,
+    Region,
+)
+
+MANIFEST_SCHEMA = "worldcovers.user_markings_manifest.v1"
+MANIFEST_FILENAME = "manifest.json"
+
+
+def backup_filename(code):
+    """Marking.code is editor-assigned free text; keep filenames path-safe."""
+    return code.replace("/", "_") + ".json"
+
+
+class Command(BaseCommand):
+    help = (
+        "Batch-export every marking carrying user-origin content (covers, "
+        "contributions, editor review, edit history) to per-marking JSON "
+        "backups via backup_marking."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "out_dir",
+            help="Directory to write per-marking JSON backups + manifest into.",
+        )
+        parser.add_argument(
+            "--state",
+            action="append",
+            default=[],
+            dest="states",
+            help="Limit to one state's markings by Region.abbrev, e.g. VA. Repeatable.",
+        )
+        parser.add_argument(
+            "--region-code",
+            action="append",
+            default=[],
+            dest="region_codes",
+            help="Limit by exact Region.code, e.g. USA-VA1. Repeatable; combined with --state.",
+        )
+        parser.add_argument(
+            "--uploader",
+            action="append",
+            default=[],
+            dest="uploaders",
+            help="Also include markings with images uploaded by this username. Repeatable.",
+        )
+        parser.add_argument(
+            "--list-only",
+            action="store_true",
+            help="Print what would be exported; write no files.",
+        )
+
+    def handle(self, *args, **options):
+        out_dir = Path(options["out_dir"])
+        if out_dir.exists() and not out_dir.is_dir():
+            raise CommandError(f"Output path is not a directory: {out_dir}")
+
+        region_filter = self._region_marking_filter(
+            options["states"], options["region_codes"]
+        )
+        markings = Marking.all_objects.filter(
+            pk__in=self._collect_marking_ids(options["uploaders"])
+        )
+        if region_filter is not None:
+            markings = markings.filter(region_filter)
+
+        coded = list(
+            markings.exclude(code__isnull=True)
+            .exclude(code="")
+            .order_by("code")
+            .values_list("code", flat=True)
+        )
+        no_code_pks = list(
+            markings.filter(Q(code__isnull=True) | Q(code=""))
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+        unlinked_cover_pks = list(
+            Cover.all_objects.exclude(
+                pk__in=CoverMarking.objects.values_list("cover_id", flat=True)
+            )
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+
+        self.stdout.write(
+            f"Markings with user content: {len(coded)} exportable, "
+            f"{len(no_code_pks)} without a code (NOT exportable)."
+        )
+        if no_code_pks:
+            self.stdout.write(
+                self.style.WARNING(
+                    "Markings without a code cannot be backed up by code and "
+                    f"will be LOST by a drop: pks {no_code_pks}"
+                )
+            )
+        if unlinked_cover_pks:
+            self.stdout.write(
+                self.style.WARNING(
+                    "Covers linked to no marking are unreachable from "
+                    f"per-marking backups: pks {unlinked_cover_pks}"
+                )
+            )
+
+        if options["list_only"]:
+            for code in coded:
+                self.stdout.write(f"  {code}")
+            return
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for code in coded:
+            path = out_dir / backup_filename(code)
+            try:
+                call_command("backup_marking", code, str(path), verbosity=0)
+            except Exception as exc:
+                raise CommandError(
+                    f"Backup failed for marking {code!r} ({exc}); aborting -- "
+                    "do NOT proceed with a drop on a partial backup set."
+                ) from exc
+
+        manifest = {
+            "schema": MANIFEST_SCHEMA,
+            "generated_at": timezone.now().isoformat(),
+            "criteria": {
+                "states": options["states"],
+                "region_codes": options["region_codes"],
+                "uploaders": options["uploaders"],
+            },
+            "codes": coded,
+            "skipped_no_code_marking_pks": no_code_pks,
+            "unlinked_cover_pks": unlinked_cover_pks,
+        }
+        (out_dir / MANIFEST_FILENAME).write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Exported {len(coded)} marking backups to {out_dir} "
+                f"(+ {MANIFEST_FILENAME})."
+            )
+        )
+
+    def _collect_marking_ids(self, uploaders):
+        ids = set(CoverMarking.objects.values_list("marking_id", flat=True))
+        ids.update(
+            Contribution.objects.exclude(marking=None).values_list(
+                "marking_id", flat=True
+            )
+        )
+        ids.update(
+            Marking.all_objects.filter(is_reviewed=True).values_list("pk", flat=True)
+        )
+        ids.update(MarkingVersion.objects.values_list("marking_id", flat=True))
+        for contribution in Contribution.objects.filter(
+            submitted_data__submission_kind="cover"
+        ):
+            marking_id = _cover_contribution_marking_id(contribution)
+            if marking_id is not None:
+                ids.add(marking_id)
+        if uploaders:
+            ids.update(
+                Image.objects.filter(
+                    subject_type=Image.SUBJECT_MARKING,
+                    uploaded_by__username__in=uploaders,
+                ).values_list("subject_id", flat=True)
+            )
+        ids.discard(None)
+        return ids
+
+    def _region_marking_filter(self, states, region_codes):
+        if not states and not region_codes:
+            return None
+        prefixes = []
+        for code in region_codes:
+            region = Region.objects.filter(code=code).first()
+            if region is None:
+                raise CommandError(f"No Region found with code={code!r}.")
+            prefixes.append(f"{region.code}-")
+        for abbrev in states:
+            matches = list(
+                Region.objects.filter(abbrev__iexact=abbrev.strip()).order_by("code")
+            )
+            if not matches:
+                raise CommandError(f"No Region found with abbrev={abbrev!r}.")
+            if len(matches) > 1:
+                codes = ", ".join(r.code or f"pk={r.pk}" for r in matches)
+                raise CommandError(
+                    f"Region abbrev {abbrev!r} is ambiguous ({codes}); "
+                    "use --region-code."
+                )
+            if not matches[0].code:
+                raise CommandError(
+                    f"Region pk={matches[0].pk} has no code; cannot scope by prefix."
+                )
+            prefixes.append(f"{matches[0].code}-")
+        region_q = Q()
+        for prefix in prefixes:
+            region_q |= Q(post_office__code__startswith=prefix)
+        return region_q

--- a/backend/common/management/commands/restore_user_markings.py
+++ b/backend/common/management/commands/restore_user_markings.py
@@ -1,0 +1,94 @@
+"""
+Batch-restore the per-marking JSON backups written by backup_user_markings.
+
+Every backup file is attempted; a failure does not stop the batch (each
+restore_marking call manages its own transaction, so a failed file rolls
+back only itself). Results are written to restore_report.json next to the
+backups: restored codes plus failures with their error messages -- the
+failure list is the editor review queue, mirroring the project's
+report-don't-guess rule for unresolvable records. The command exits with an
+error when anything failed so operators notice, but by then everything
+restorable has been restored.
+
+Usage:
+    python backend/manage.py restore_user_markings ./tools/wip/user-backups --dry-run
+    python backend/manage.py restore_user_markings ./tools/wip/user-backups
+"""
+import json
+from pathlib import Path
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from common.management.commands.backup_user_markings import MANIFEST_FILENAME
+
+REPORT_FILENAME = "restore_report.json"
+REPORT_SCHEMA = "worldcovers.user_markings_restore_report.v1"
+
+
+class Command(BaseCommand):
+    help = (
+        "Batch-restore per-marking JSON backups (from backup_user_markings), "
+        "continuing past failures and writing a restore_report.json review list."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "in_dir",
+            help="Directory containing per-marking JSON backups.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Validate every file (each restore rolled back); commit nothing.",
+        )
+
+    def handle(self, *args, **options):
+        in_dir = Path(options["in_dir"])
+        if not in_dir.is_dir():
+            raise CommandError(f"Input path is not a directory: {in_dir}")
+        dry_run = bool(options["dry_run"])
+
+        skip = {MANIFEST_FILENAME, REPORT_FILENAME}
+        files = sorted(
+            path for path in in_dir.glob("*.json") if path.name not in skip
+        )
+        if not files:
+            raise CommandError(f"No backup files found in {in_dir}.")
+
+        restored, failures = [], []
+        for path in files:
+            try:
+                call_command(
+                    "restore_marking", str(path), dry_run=dry_run, verbosity=0
+                )
+            except Exception as exc:
+                failures.append({"file": path.name, "error": str(exc)})
+                self.stdout.write(self.style.ERROR(f"FAILED  {path.name}: {exc}"))
+            else:
+                restored.append(path.name)
+                self.stdout.write(f"restored {path.name}")
+
+        report = {
+            "schema": REPORT_SCHEMA,
+            "generated_at": timezone.now().isoformat(),
+            "dry_run": dry_run,
+            "restored": restored,
+            "failures": failures,
+        }
+        report_path = in_dir / REPORT_FILENAME
+        report_path.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        summary = (
+            f"{len(restored)}/{len(files)} backups "
+            + ("validated" if dry_run else "restored")
+        )
+        if failures:
+            raise CommandError(
+                f"{summary}; {len(failures)} FAILED -- review {report_path}."
+            )
+        self.stdout.write(self.style.SUCCESS(f"{summary}; report: {report_path}"))

--- a/backend/common/tests/test_user_markings_batch.py
+++ b/backend/common/tests/test_user_markings_batch.py
@@ -1,0 +1,150 @@
+import json
+import tempfile
+from pathlib import Path
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from common.models import (
+    Collection,
+    Color,
+    Cover,
+    CoverMarking,
+    Marking,
+    PostOffice,
+    PostOfficeRegion,
+    Region,
+)
+
+
+User = get_user_model()
+
+
+class UserMarkingsBatchTests(TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.out_dir = Path(self.tmp.name) / "backups"
+
+        self.editor = User.objects.create_superuser(
+            username="editor", email="editor@example.com", password="pw"
+        )
+        audit = {"created_by": self.editor, "modified_by": self.editor}
+        self.color = Color.objects.create(name="Black", **audit)
+        self.region = Region.objects.create(
+            name="Virginia", abbrev="VA", code="USA-VA1", region_tier="STATE", **audit
+        )
+        Collection.objects.create(name="Virginia", region=self.region, **audit)
+        self.post_office = PostOffice.objects.create(
+            name="Richmond", code="USA-VA1-RICH", **audit
+        )
+        PostOfficeRegion.objects.create(
+            post_office=self.post_office, region=self.region, **audit
+        )
+
+        # Signal: has a cover -> must be backed up.
+        self.covered = Marking.objects.create(
+            code="ASCC1-VA-M0001",
+            type="TOWNMARK",
+            inscription_txt="RICHMOND VA",
+            is_manuscript=False,
+            color=self.color,
+            post_office=self.post_office,
+            **audit,
+        )
+        self.cover = Cover.objects.create(
+            code="ASCC1-VA-C0001", color=self.color, type="FC", **audit
+        )
+        CoverMarking.objects.create(
+            cover=self.cover,
+            marking=self.covered,
+            review_status=CoverMarking.REVIEW_APPROVED,
+            reviewer=self.editor,
+            **audit,
+        )
+
+        # Signal: editor-vetted, no cover -> must still be backed up.
+        self.reviewed = Marking.objects.create(
+            code="ASCC1-VA-M0002",
+            type="RATEMARK",
+            inscription_txt="PAID 5",
+            is_manuscript=False,
+            post_office=self.post_office,
+            is_reviewed=True,
+            **audit,
+        )
+
+        # Pure catalog row, untouched -> must NOT be backed up.
+        self.pristine = Marking.objects.create(
+            code="ASCC1-VA-M0003",
+            type="AUXMARK",
+            inscription_txt="FORWARDED",
+            is_manuscript=False,
+            post_office=self.post_office,
+            **audit,
+        )
+
+    def _manifest(self):
+        return json.loads((self.out_dir / "manifest.json").read_text())
+
+    def test_backup_selects_user_content_markings_only(self):
+        call_command("backup_user_markings", str(self.out_dir), verbosity=0)
+
+        manifest = self._manifest()
+        self.assertEqual(
+            manifest["codes"], [self.covered.code, self.reviewed.code]
+        )
+        self.assertTrue((self.out_dir / f"{self.covered.code}.json").exists())
+        self.assertTrue((self.out_dir / f"{self.reviewed.code}.json").exists())
+        self.assertFalse((self.out_dir / f"{self.pristine.code}.json").exists())
+
+    def test_backup_reports_markings_without_code(self):
+        no_code = Marking.objects.create(
+            type="TOWNMARK",
+            inscription_txt="NORFOLK VA",
+            is_manuscript=False,
+            post_office=self.post_office,
+            is_reviewed=True,
+            created_by=self.editor,
+            modified_by=self.editor,
+        )
+        call_command("backup_user_markings", str(self.out_dir), verbosity=0)
+        self.assertEqual(
+            self._manifest()["skipped_no_code_marking_pks"], [no_code.pk]
+        )
+
+    def test_round_trip_restores_covers_after_state_drop(self):
+        call_command("backup_user_markings", str(self.out_dir), verbosity=0)
+        call_command("drop_ascc_state", "VA", verbosity=0)
+        self.assertFalse(Cover.all_objects.filter(code=self.cover.code).exists())
+        self.assertFalse(Marking.all_objects.filter(code=self.covered.code).exists())
+
+        call_command("restore_user_markings", str(self.out_dir), verbosity=0)
+
+        restored_cover = Cover.all_objects.get(code=self.cover.code)
+        self.assertTrue(
+            CoverMarking.objects.filter(
+                cover=restored_cover, marking__code=self.covered.code
+            ).exists()
+        )
+        self.assertTrue(
+            Marking.all_objects.filter(code=self.reviewed.code).exists()
+        )
+        report = json.loads((self.out_dir / "restore_report.json").read_text())
+        self.assertEqual(len(report["restored"]), 2)
+        self.assertEqual(report["failures"], [])
+
+    def test_restore_continues_past_bad_file_and_reports_it(self):
+        call_command("backup_user_markings", str(self.out_dir), verbosity=0)
+        bad = self.out_dir / "AAA-corrupt.json"
+        bad.write_text("{not json")
+
+        with self.assertRaises(CommandError):
+            call_command("restore_user_markings", str(self.out_dir), verbosity=0)
+
+        report = json.loads((self.out_dir / "restore_report.json").read_text())
+        self.assertEqual(len(report["restored"]), 2)
+        self.assertEqual(len(report["failures"]), 1)
+        self.assertEqual(report["failures"][0]["file"], bad.name)

--- a/docs/devel/USER_SAFE_REFRESH.md
+++ b/docs/devel/USER_SAFE_REFRESH.md
@@ -1,0 +1,54 @@
+# User-safe catalog refresh (drop + re-import without losing user data)
+
+`drop_ascc_state` deletes a state's catalog tree **including** the
+user-submitted covers, images, dates, citations, and contributions hanging
+off its markings — and post-policy bundles contain no covers, so nothing
+puts them back. This runbook wraps the drop/re-import in the batch
+backup/restore commands so user content survives.
+
+Related: `docs/devel/PIPELINE.md` (bundle production), `AUTH_SYNC.md`
+(auth tables move separately via `backup_auth`/`restore_auth`).
+
+## Sequence
+
+```bash
+# 0. Preflight — enumerate what will be preserved; check the warnings.
+python backend/manage.py backup_user_markings ./tools/wip/user-backups --list-only
+
+# 1. Backup (fail-fast: any export error aborts before anything is dropped).
+python backend/manage.py backup_user_markings ./tools/wip/user-backups
+
+# 2. Drop each state being refreshed (dry-run first).
+python backend/manage.py drop_ascc_state VA --dry-run
+python backend/manage.py drop_ascc_state VA
+
+# 3. Re-import the re-run bundles (natural-key incremental).
+python backend/manage.py import_apmc_bundle ./tools/wip/out/
+
+# 4. Restore user content (dry-run first; failures don't stop the batch).
+python backend/manage.py restore_user_markings ./tools/wip/user-backups --dry-run
+python backend/manage.py restore_user_markings ./tools/wip/user-backups
+
+# 5. Review ./tools/wip/user-backups/restore_report.json — the `failures`
+#    list is the editor review queue (markings whose codes no longer resolve
+#    after the re-run are reported, never silently dropped).
+```
+
+## Caveats
+
+- **Markings without a `code` cannot be backed up** (`backup_marking` is
+  code-keyed). The backup manifest lists their pks; they will be lost by a
+  drop unless handled manually first.
+- **Covers linked to no marking** are unreachable from per-marking backups;
+  also listed in the manifest.
+- **Image binaries are not copied** — backups carry `storage_filename`
+  metadata only. Media files under `MEDIA_ROOT` are untouched by the drop,
+  so restored rows re-link to the files already on disk. Verify a sample
+  image renders after restore.
+- **Restoring an editor-edited marking re-applies its backed-up field
+  values** over the freshly imported row (editor data wins over munger
+  output for markings a person actually touched). This is intentional;
+  it also means such rows do not pick up munger fixes — the restore report
+  tells you which rows those are.
+- Prove the full sequence on a **local copy of the production/dev DB**
+  before running it on woco.dev or prod.


### PR DESCRIPTION
## What

Thin orchestration around the existing per-marking backup/restore so a `drop_ascc_state` → `import_apmc_bundle` refresh no longer destroys user-submitted content:

- **`backup_user_markings <dir>`** — enumerates every marking carrying user-origin content (has covers, contributions, `is_reviewed=True`, edit history, or `--uploader <username>` images) and exports each via `backup_marking`. Fail-fast: any export error aborts before a drop can run against a partial backup set. Writes `manifest.json` reporting what could NOT be exported (markings without a `code`, covers linked to no marking) instead of silently skipping.
- **`restore_user_markings <dir> [--dry-run]`** — restores every backup, continues past failures (each `restore_marking` is transactional on its own), writes `restore_report.json`; the `failures` list is the editor review queue. Exits nonzero if anything failed.
- **`docs/devel/USER_SAFE_REFRESH.md`** — the wrapped sequence + caveats (code-less markings, media binaries, editor-edits-win-over-munger semantics).

## Why

`drop_ascc_state` cascades through `CoverMarking` and deletes user covers/images/contributions, and post-policy bundles contain no covers — so a refresh of woco.dev (needed so Ian stops reviewing stale edition-5 data, per his 6/28–29 emails) would wipe his and Wayne's submissions. This is also the prerequisite for any future prod re-run.

## Tests

- `common.tests.test_user_markings_batch` (4 tests): enumeration selects only user-content markings; no-code markings land in the manifest; full round-trip `backup → drop_ascc_state VA → restore` brings back covers/links/markings; a corrupt file doesn't stop the batch and is reported.
- Full `common` suite: **134/135** — the one failure (`test_top_search_ignores_catalog_text`) pre-exists on staging tip `0998d6a` with this branch's files removed (verified via stash) and is unrelated (top-search vs `catalog_txt` semantics). @grubermeister flagging it for you since it's in the search area you've been changing.

ruff clean, `manage.py check` clean, no schema changes.

## Not in this PR

The actual woco.dev refresh run (needs coordination on who runs it + re-run bundles), and the post-refresh re-measurement of Ian's reports (Abingdon 7/7/9, FL Almirante/Almirante/Alaqua manuscripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)