### PR TITLE
#47: link existing covers ↔ existing markings from the detail pages

### DIFF
--- a/frontend/src/lib/recordLinking.test.ts
+++ b/frontend/src/lib/recordLinking.test.ts
@@ -1,0 +1,30 @@
+import { parseCoverIdInput, parseMarkingIdInput } from "./recordLinking";
+
+describe("parseCoverIdInput", () => {
+  it("accepts bare ids and C- prefixed codes", () => {
+    expect(parseCoverIdInput("42")).toBe(42);
+    expect(parseCoverIdInput("C-42")).toBe(42);
+    expect(parseCoverIdInput("c42")).toBe(42);
+    expect(parseCoverIdInput(" 42 ")).toBe(42);
+  });
+
+  it("rejects non-linkable input", () => {
+    expect(parseCoverIdInput("")).toBeNull();
+    expect(parseCoverIdInput("0")).toBeNull();
+    expect(parseCoverIdInput("-3")).toBeNull();
+    expect(parseCoverIdInput("cover")).toBeNull();
+  });
+});
+
+describe("parseMarkingIdInput", () => {
+  it("accepts bare ids and api- route ids", () => {
+    expect(parseMarkingIdInput("12")).toBe(12);
+    expect(parseMarkingIdInput("api-12")).toBe(12);
+  });
+
+  it("rejects non-linkable input", () => {
+    expect(parseMarkingIdInput("")).toBeNull();
+    expect(parseMarkingIdInput("api-")).toBeNull();
+    expect(parseMarkingIdInput("marking")).toBeNull();
+  });
+});

--- a/frontend/src/lib/recordLinking.ts
+++ b/frontend/src/lib/recordLinking.ts
@@ -1,0 +1,16 @@
+/**
+ * Input parsing for the "Link Existing Cover / Marking" dialogs (issue #47).
+ *
+ * Editors paste IDs in the forms they see around the site: bare numbers,
+ * cover codes like "C-42" / "c42", or marking route ids like "api-12".
+ * Returns the positive integer id, or null when the input is not linkable.
+ */
+export function parseCoverIdInput(raw: string): number | null {
+  const value = parseInt(raw.trim().replace(/^[Cc]-?/, ""), 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+export function parseMarkingIdInput(raw: string): number | null {
+  const value = parseInt(raw.trim().replace(/^api-/, ""), 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}

--- a/frontend/src/pages/CoverDetail.tsx
+++ b/frontend/src/pages/CoverDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { CheckCircle, Info, Loader2, MessageSquare, Pencil, Trash2, XCircle } from "lucide-react";
+import { CheckCircle, Info, Loader2, MessageSquare, Pencil, Plus, Trash2, XCircle } from "lucide-react";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import {
   getImagesForSubject,
+  getMarkingById,
   getMarkingChangelog,
   getCoverMarkingsByCover,
   deleteImage,
@@ -55,12 +56,15 @@ import {
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  createCoverMarking,
   getCoverById,
   removeCover,
   restoreCover,
   type CoverDetail,
   type CoverDateSeenItem,
 } from "@/services/covers";
+import { Input } from "@/components/ui/input";
+import { parseMarkingIdInput } from "@/lib/recordLinking";
 import { listCitationsForSubject } from "@/services/citations";
 import { getReferenceWorks, type ReferenceWorkRecord } from "@/services/referenceWorks";
 import { SUBMISSION_LABELS } from "@/labels/submission";
@@ -157,6 +161,10 @@ const CoverDetailPage = () => {
   const [restoreOpen, setRestoreOpen] = useState(false);
   const [restoring, setRestoring] = useState(false);
   const [deletingImageId, setDeletingImageId] = useState<number | null>(null);
+  const [linkMarkingOpen, setLinkMarkingOpen] = useState(false);
+  const [linkMarkingInput, setLinkMarkingInput] = useState("");
+  const [linkMarkingBusy, setLinkMarkingBusy] = useState(false);
+  const [linkMarkingError, setLinkMarkingError] = useState<string | null>(null);
 
   const isStaff =
     !!user &&
@@ -498,6 +506,50 @@ const CoverDetailPage = () => {
     return false;
   };
 
+  // Creates a CoverMarking junction row between this cover and an
+  // already-existing marking. The endpoint is editor/admin-gated
+  // (IsEditorOrAdminWrite), so the button only renders for isStaff.
+  const handleLinkExistingMarking = async () => {
+    if (coverPk == null) return;
+    const markingIdTarget = parseMarkingIdInput(linkMarkingInput);
+    if (markingIdTarget == null) {
+      setLinkMarkingError("Enter a valid marking ID.");
+      return;
+    }
+    setLinkMarkingBusy(true);
+    setLinkMarkingError(null);
+    try {
+      const marking = await getMarkingById(markingIdTarget);
+      if (!marking) {
+        setLinkMarkingError(`Marking ${markingIdTarget} not found.`);
+        return;
+      }
+      await createCoverMarking({ cover: coverPk, marking: markingIdTarget });
+      toast({
+        title: "Marking linked",
+        description: `Marking ${marking.code ?? markingIdTarget} is now linked to this cover.`,
+      });
+      setLinkMarkingOpen(false);
+      setLinkMarkingInput("");
+      const linksResult = await getCoverMarkingsByCover(coverPk);
+      const linkForMarking =
+        markingId != null
+          ? linksResult.links.find((l) => l.markingId === markingId) ?? null
+          : linksResult.links[0] ?? null;
+      setCoverMarkingLink(linkForMarking);
+      const markings = await loadAssociatedMarkingsForCover(linksResult.links);
+      setAssociatedMarkings(markings);
+    } catch (err: unknown) {
+      const ax = err as { response?: { data?: { detail?: string; non_field_errors?: string[] } } };
+      const detail = ax.response?.data?.detail ?? ax.response?.data?.non_field_errors?.[0];
+      setLinkMarkingError(
+        typeof detail === "string" ? detail : "Could not link marking. It may already be linked.",
+      );
+    } finally {
+      setLinkMarkingBusy(false);
+    }
+  };
+
   const openEditCover = () => {
     if (markingId == null || coverPk == null) return;
     if (!requireAuth()) return;
@@ -743,9 +795,25 @@ const CoverDetailPage = () => {
 
             <Card className="shadow-archival-md">
               <CardHeader>
-                <CardTitle className="font-heading text-lg">
-                  Associated Markings ({associatedMarkingCount})
-                </CardTitle>
+                <div className="flex items-center justify-between gap-3">
+                  <CardTitle className="font-heading text-lg">
+                    Associated Markings ({associatedMarkingCount})
+                  </CardTitle>
+                  {isStaff && !cover.isRemoved && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setLinkMarkingInput("");
+                        setLinkMarkingError(null);
+                        setLinkMarkingOpen(true);
+                      }}
+                    >
+                      <Plus className="mr-2 h-4 w-4" />
+                      Link Existing Marking
+                    </Button>
+                  )}
+                </div>
               </CardHeader>
               <CardContent className="space-y-4 pt-0">
                 {markingsLoadError && (
@@ -777,6 +845,64 @@ const CoverDetailPage = () => {
           </>
         }
       />
+
+      <Dialog
+        open={linkMarkingOpen}
+        onOpenChange={(open) => {
+          if (linkMarkingBusy) return;
+          setLinkMarkingOpen(open);
+          if (!open) {
+            setLinkMarkingInput("");
+            setLinkMarkingError(null);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Link Existing Marking</DialogTitle>
+            <DialogDescription>
+              Enter the marking ID to link it to this cover.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <Input
+              placeholder="Marking ID"
+              value={linkMarkingInput}
+              onChange={(e) => {
+                setLinkMarkingInput(e.target.value);
+                setLinkMarkingError(null);
+              }}
+              disabled={linkMarkingBusy}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleLinkExistingMarking();
+                }
+              }}
+              autoFocus
+            />
+            {linkMarkingError && <p className="text-sm text-destructive">{linkMarkingError}</p>}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setLinkMarkingOpen(false)} disabled={linkMarkingBusy}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleLinkExistingMarking()}
+              disabled={linkMarkingBusy || !linkMarkingInput.trim()}
+            >
+              {linkMarkingBusy ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Linking…
+                </>
+              ) : (
+                "Link Marking"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={removeOpen} onOpenChange={(open) => !removing && setRemoveOpen(open)}>
         <DialogContent>

--- a/frontend/src/pages/RecordDetail.tsx
+++ b/frontend/src/pages/RecordDetail.tsx
@@ -63,6 +63,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useToast } from "@/hooks/use-toast";
 import { SUBMISSION_LABELS } from "@/labels/submission";
 import { useAuth } from "@/hooks/useAuth";
+import { Input } from "@/components/ui/input";
+import { createCoverMarking, getCoverById } from "@/services/covers";
+import { parseCoverIdInput } from "@/lib/recordLinking";
 
 type GalleryImage = {
   imageUrl: string | null;
@@ -303,6 +306,10 @@ const RecordDetail = () => {
   const [removing, setRemoving] = useState(false);
   const [restoreOpen, setRestoreOpen] = useState(false);
   const [restoring, setRestoring] = useState(false);
+  const [linkCoverOpen, setLinkCoverOpen] = useState(false);
+  const [linkCoverInput, setLinkCoverInput] = useState("");
+  const [linkCoverBusy, setLinkCoverBusy] = useState(false);
+  const [linkCoverError, setLinkCoverError] = useState<string | null>(null);
   const [savingReviewed, setSavingReviewed] = useState(false);
   const [deletingImageId, setDeletingImageId] = useState<number | null>(null);
 
@@ -718,6 +725,45 @@ const RecordDetail = () => {
       state: { from: location.pathname + location.search },
     });
   };
+
+  // Creates a CoverMarking junction row between this marking and an
+  // already-existing cover. The endpoint is editor/admin-gated
+  // (IsEditorOrAdminWrite), so the button only renders for isStaff.
+  const handleLinkExistingCover = async () => {
+    if (markingId == null) return;
+    const coverId = parseCoverIdInput(linkCoverInput);
+    if (coverId == null) {
+      setLinkCoverError("Enter a valid cover ID (e.g. 42 or C-42).");
+      return;
+    }
+    setLinkCoverBusy(true);
+    setLinkCoverError(null);
+    try {
+      const cover = await getCoverById(coverId);
+      if (!cover) {
+        setLinkCoverError(`Cover ${coverId} not found.`);
+        return;
+      }
+      await createCoverMarking({ cover: coverId, marking: markingId });
+      toast({
+        title: "Cover linked",
+        description: `Cover ${cover.code ?? coverId} is now linked to this marking.`,
+      });
+      setLinkCoverOpen(false);
+      setLinkCoverInput("");
+      const { covers: rows, error: coversErr } = await loadAssociatedCoversForMarking(markingId);
+      setCoversLoadError(coversErr);
+      setAssociatedCovers(rows);
+    } catch (err: unknown) {
+      const ax = err as { response?: { data?: { detail?: string; non_field_errors?: string[] } } };
+      const detail = ax.response?.data?.detail ?? ax.response?.data?.non_field_errors?.[0];
+      setLinkCoverError(
+        typeof detail === "string" ? detail : "Could not link cover. It may already be linked.",
+      );
+    } finally {
+      setLinkCoverBusy(false);
+    }
+  };
   const goCoverView = (cover: AssociatedCover) => {
     if (markingId == null) return;
     if (cover.contributionDraftId != null) {
@@ -1086,14 +1132,30 @@ const RecordDetail = () => {
                     </CardTitle>
                     {/* No new covers can be attached to a removed marking. */}
                     {!record.isRemoved && (
-                      <Button
-                        size="sm"
-                        onClick={openNewCoverDialog}
-                        className="bg-green-800 hover:bg-green-900 text-white"
-                      >
-                        <Plus className="mr-2 h-4 w-4" />
-                        {SUBMISSION_LABELS.action.submitNewCover}
-                      </Button>
+                      <div className="flex gap-2">
+                        {isStaff && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                              setLinkCoverInput("");
+                              setLinkCoverError(null);
+                              setLinkCoverOpen(true);
+                            }}
+                          >
+                            <Plus className="mr-2 h-4 w-4" />
+                            Link Existing Cover
+                          </Button>
+                        )}
+                        <Button
+                          size="sm"
+                          onClick={openNewCoverDialog}
+                          className="bg-green-800 hover:bg-green-900 text-white"
+                        >
+                          <Plus className="mr-2 h-4 w-4" />
+                          {SUBMISSION_LABELS.action.submitNewCover}
+                        </Button>
+                      </div>
                     )}
                   </div>
                 </CardHeader>
@@ -1412,6 +1474,64 @@ const RecordDetail = () => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <Dialog
+        open={linkCoverOpen}
+        onOpenChange={(open) => {
+          if (linkCoverBusy) return;
+          setLinkCoverOpen(open);
+          if (!open) {
+            setLinkCoverInput("");
+            setLinkCoverError(null);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Link Existing Cover</DialogTitle>
+            <DialogDescription>
+              Enter the cover ID or code (e.g. 42 or C-42) to link it to this marking.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <Input
+              placeholder="Cover ID or code"
+              value={linkCoverInput}
+              onChange={(e) => {
+                setLinkCoverInput(e.target.value);
+                setLinkCoverError(null);
+              }}
+              disabled={linkCoverBusy}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleLinkExistingCover();
+                }
+              }}
+              autoFocus
+            />
+            {linkCoverError && <p className="text-sm text-destructive">{linkCoverError}</p>}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setLinkCoverOpen(false)} disabled={linkCoverBusy}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleLinkExistingCover()}
+              disabled={linkCoverBusy || !linkCoverInput.trim()}
+            >
+              {linkCoverBusy ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Linking…
+                </>
+              ) : (
+                "Link Cover"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Footer />
     </div>


### PR DESCRIPTION
## What

Michael's ask: "relate an existing cover to one or more existing markings, and relate an existing marking to one or more covers. Currently you can only add entirely new covers and they're assigned to the one marking."

- **RecordDetail** (marking page): a **Link Existing Cover** button next to Submit New Cover opens a dialog accepting a cover ID or code (`42` / `C-42`), verifies it via `getCoverById`, POSTs the existing `cover-markings` endpoint, and refreshes the Associated Covers list in place. Duplicate/validation errors surface in the dialog.
- **CoverDetail**: a **Link Existing Marking** button on the Associated Markings card, same flow via `getMarkingById` + `createCoverMarking`.
- Linking is one-at-a-time but repeatable, so "one or more" is covered; bulk multi-select can layer on later if editors want it.
- ID parsing extracted to `lib/recordLinking.ts` with unit tests.

## Gating decision

Both buttons render only for editor/admin (`isStaff`). The endpoint is `IsEditorOrAdminWrite`, so a contributor-visible button would just 403 on submit — frontend now matches the backend's permission. If we want contributors linking covers, that's a backend permission change to make deliberately, not a UI default.

## Zero backend changes

`CoverMarkingViewSet` + `createCoverMarking` already shipped; this is UI plumbing only. Ported by hand from the pre-refactor `reese/cover-workflow-improvements` branch — the image-move half of that branch lands separately as #48.

## Tests

jest 53/53 (12 suites, +4 new for ID parsing), `tsc --noEmit` clean, eslint clean, vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)